### PR TITLE
 Fix: Improve error handling for missing SSH client and add unit tests for `shell` command

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -109,6 +109,7 @@ require (
 	github.com/skeema/knownhosts v1.1.0 // indirect
 	github.com/spf13/cast v1.5.0 // indirect
 	github.com/spf13/jwalterweatherman v1.1.0 // indirect
+	github.com/stretchr/objx v0.4.0 // indirect
 	github.com/subosito/gotenv v1.4.1 // indirect
 	github.com/tidwall/match v1.1.1 // indirect
 	github.com/tidwall/pretty v1.2.0 // indirect

--- a/pkg/cmd/ls/ls.go
+++ b/pkg/cmd/ls/ls.go
@@ -228,7 +228,6 @@ func handleLsArg(ls *Ls, arg string, user *entity.User, org *entity.Organization
 	return nil
 }
 
-
 type Ls struct {
 	lsStore  LsStore
 	terminal *terminal.Terminal

--- a/pkg/cmd/ls/ls.go
+++ b/pkg/cmd/ls/ls.go
@@ -186,7 +186,7 @@ func RunLs(t *terminal.Terminal, lsStore LsStore, args []string, orgflag string,
 func handleLsArg(ls *Ls, arg string, user *entity.User, org *entity.Organization, showAll bool) error {
 	// todo refactor this to cmd.register
 	switch {
-	case util.IsSingularOrPlural(arg, "org") || util.IsSingularOrPlural(arg, "orgisation"):
+	case util.IsSingularOrPlural(arg, "org") || util.IsSingularOrPlural(arg, "organization"):
 		// Handle organizations
 		if err := ls.RunOrgs(); err != nil {
 			return breverrors.WrapAndTrace(err)

--- a/pkg/cmd/ls/ls.go
+++ b/pkg/cmd/ls/ls.go
@@ -89,7 +89,13 @@ func NewCmdLs(t *terminal.Terminal, loginLsStore LsStore, noLoginLsStore LsStore
 
 			return nil
 		},
-		Args:      cmderrors.TransformToValidationError(cobra.OnlyValidArgs),
+		Args: cmderrors.TransformToValidationError(func(cmd *cobra.Command, args []string) error {
+			// Allow 0 or 1 argument, and only valid ones
+			if len(args) > 1 {
+				return fmt.Errorf("this command accepts only zero or one argument")
+			}
+			return cobra.OnlyValidArgs(cmd, args)
+		}),
 		ValidArgs: []string{"org", "orgs", "organization", "organizations", "workspace", "workspaces", "user", "users", "host", "hosts"},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			err := RunLs(t, loginLsStore, args, org, showAll)

--- a/pkg/cmd/ls/ls_test.go
+++ b/pkg/cmd/ls/ls_test.go
@@ -75,10 +75,10 @@ func TestLsCommand_RunLs_NoArgs(t *testing.T) {
 	}
 	testWorkspaces := []entity.Workspace{
 		{
-			ID:             "workspace-1",
-			Name:           "Workspace 1",
+			ID:              "workspace-1",
+			Name:            "Workspace 1",
 			CreatedByUserID: "test-user-id",
-			Status:         entity.Running,
+			Status:          entity.Running,
 		},
 	}
 
@@ -88,7 +88,6 @@ func TestLsCommand_RunLs_NoArgs(t *testing.T) {
 	mockLsStore.On("GetOrganizations", (*store.GetOrganizationsOptions)(nil)).Return([]entity.Organization{*testOrg}, nil)
 	mockLsStore.On("UpdateUser", testUser.ID, mock.AnythingOfType("*entity.UpdateUser")).Return(testUser, nil)
 	mockLsStore.On("GetCurrentWorkspaceID").Return("workspace-1", nil)
-
 
 	cmd := NewCmdLs(mockTerminal, mockLsStore, mockLsStore)
 
@@ -207,10 +206,10 @@ func TestLsCommand_RunLs_WithOrgFlag(t *testing.T) {
 	}
 	testWorkspaces := []entity.Workspace{
 		{
-			ID:             "workspace-1",
-			Name:           "Workspace 1",
+			ID:              "workspace-1",
+			Name:            "Workspace 1",
 			CreatedByUserID: "test-user-id",
-			Status:         entity.Running,
+			Status:          entity.Running,
 		},
 	}
 
@@ -248,16 +247,16 @@ func TestLsCommand_RunLs_AllFlag(t *testing.T) {
 	}
 	allWorkspaces := []entity.Workspace{
 		{
-			ID:             "workspace-1",
-			Name:           "Workspace 1",
+			ID:              "workspace-1",
+			Name:            "Workspace 1",
 			CreatedByUserID: "test-user-id",
-			Status:         entity.Running,
+			Status:          entity.Running,
 		},
 		{
-			ID:             "workspace-2",
-			Name:           "Workspace 2",
+			ID:              "workspace-2",
+			Name:            "Workspace 2",
 			CreatedByUserID: "test-user-id-2",
-			Status:         entity.Stopped,
+			Status:          entity.Stopped,
 		},
 	}
 
@@ -278,6 +277,4 @@ func TestLsCommand_RunLs_AllFlag(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Contains(t, verboseBuffer.String(), "You have 1 instances in Org test-org\nno other projects in Org test-org\n%!(EXTRA int=0)Invite a teamate:\n\tbrev invite")
 	assert.Contains(t, outBuffer.String(), " NAME          STATUS   ID           MACHINE \n Workspace 1   RUNNING  workspace-1   (gpu)  \n")
-
 }
-

--- a/pkg/cmd/ls/ls_test.go
+++ b/pkg/cmd/ls/ls_test.go
@@ -1,1 +1,283 @@
 package ls
+
+import (
+	"testing"
+
+	"github.com/brevdev/brev-cli/pkg/entity"
+	"github.com/brevdev/brev-cli/pkg/store"
+	"github.com/brevdev/brev-cli/pkg/terminal"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+// MockLsStore is a mock implementation of the LsStore interface
+type MockLsStore struct {
+	mock.Mock
+}
+
+func (m *MockLsStore) UpdateUser(userID string, updatedUser *entity.UpdateUser) (*entity.User, error) {
+	args := m.Called(userID, updatedUser)
+	return args.Get(0).(*entity.User), args.Error(1)
+}
+
+func (m *MockLsStore) GetCurrentWorkspaceID() (string, error) {
+	args := m.Called()
+	return args.String(0), args.Error(1)
+}
+
+func (m *MockLsStore) GetAllWorkspaces(options *store.GetWorkspacesOptions) ([]entity.Workspace, error) {
+	args := m.Called()
+	return args.Get(0).([]entity.Workspace), args.Error(1)
+}
+
+func (m *MockLsStore) GetWorkspaces(organizationID string, options *store.GetWorkspacesOptions) ([]entity.Workspace, error) {
+	args := m.Called(organizationID, options)
+	return args.Get(0).([]entity.Workspace), args.Error(1)
+}
+
+func (m *MockLsStore) GetActiveOrganizationOrDefault() (*entity.Organization, error) {
+	args := m.Called()
+	return args.Get(0).(*entity.Organization), args.Error(1)
+}
+
+func (m *MockLsStore) GetCurrentUser() (*entity.User, error) {
+	args := m.Called()
+	return args.Get(0).(*entity.User), args.Error(1)
+}
+
+func (m *MockLsStore) GetUsers(queryParams map[string]string) ([]entity.User, error) {
+	args := m.Called(queryParams)
+	return args.Get(0).([]entity.User), args.Error(1)
+}
+
+func (m *MockLsStore) GetWorkspace(workspaceID string) (*entity.Workspace, error) {
+	args := m.Called(workspaceID)
+	return args.Get(0).(*entity.Workspace), args.Error(1)
+}
+
+func (m *MockLsStore) GetOrganizations(options *store.GetOrganizationsOptions) ([]entity.Organization, error) {
+	args := m.Called(options)
+	return args.Get(0).([]entity.Organization), args.Error(1)
+}
+
+func TestLsCommand_RunLs_NoArgs(t *testing.T) {
+	mockTerminal, outBuffer, verboseBuffer, errBuffer := terminal.NewTestTerminal()
+
+	mockLsStore := new(MockLsStore)
+	testOrg := &entity.Organization{
+		ID:   "test-org-id",
+		Name: "test-org",
+	}
+	testUser := &entity.User{
+		ID:   "test-user-id",
+		Name: "Test User",
+	}
+	testWorkspaces := []entity.Workspace{
+		{
+			ID:             "workspace-1",
+			Name:           "Workspace 1",
+			CreatedByUserID: "test-user-id",
+			Status:         entity.Running,
+		},
+	}
+
+	mockLsStore.On("GetCurrentUser").Return(testUser, nil)
+	mockLsStore.On("GetActiveOrganizationOrDefault").Return(testOrg, nil)
+	mockLsStore.On("GetWorkspaces", "test-org-id", (*store.GetWorkspacesOptions)(nil)).Return(testWorkspaces, nil)
+	mockLsStore.On("GetOrganizations", (*store.GetOrganizationsOptions)(nil)).Return([]entity.Organization{*testOrg}, nil)
+	mockLsStore.On("UpdateUser", testUser.ID, mock.AnythingOfType("*entity.UpdateUser")).Return(testUser, nil)
+	mockLsStore.On("GetCurrentWorkspaceID").Return("workspace-1", nil)
+
+
+	cmd := NewCmdLs(mockTerminal, mockLsStore, mockLsStore)
+
+	cmd.SetOut(outBuffer)
+	cmd.SetErr(errBuffer)
+	// Execute the command without any arguments
+	cmd.SetArgs([]string{})
+
+	err := cmd.Execute()
+	assert.NoError(t, err)
+	assert.Contains(t, verboseBuffer.String(), "You have 1 instances in Org test-org")
+	assert.Contains(t, outBuffer.String(), "NAME          STATUS   ID           MACHINE \n Workspace 1   RUNNING  workspace-1   (gpu)  \n")
+}
+
+func TestLsCommand_RunLs_OrgArg(t *testing.T) {
+	mockTerminal, outBuffer, verboseBuffer, errBuffer := terminal.NewTestTerminal()
+
+	mockLsStore := new(MockLsStore)
+	testOrg := &entity.Organization{
+		ID:   "test-org-id",
+		Name: "test-org",
+	}
+	testUser := &entity.User{
+		ID:   "test-user-id",
+		Name: "Test User",
+	}
+
+	mockLsStore.On("GetCurrentUser").Return(testUser, nil)
+	mockLsStore.On("GetOrganizations", (*store.GetOrganizationsOptions)(nil)).Return([]entity.Organization{*testOrg}, nil)
+	mockLsStore.On("UpdateUser", testUser.ID, mock.AnythingOfType("*entity.UpdateUser")).Return(testUser, nil)
+	mockLsStore.On("GetCurrentWorkspaceID").Return("workspace-1", nil)
+	mockLsStore.On("GetActiveOrganizationOrDefault").Return(testOrg, nil)
+
+	cmd := NewCmdLs(mockTerminal, mockLsStore, mockLsStore)
+	cmd.SetOut(outBuffer)
+	cmd.SetErr(errBuffer)
+
+	// Execute the command with the "org" argument
+	cmd.SetArgs([]string{"org"})
+
+	err := cmd.Execute()
+	assert.NoError(t, err)
+	assert.Contains(t, verboseBuffer.String(), "Your organizations:")
+	assert.Contains(t, outBuffer.String(), "* test-org")
+}
+
+func TestLsCommand_RunLs_InvalidArg(t *testing.T) {
+	mockTerminal, outBuffer, _, errBuffer := terminal.NewTestTerminal()
+
+	mockLsStore := new(MockLsStore)
+	testOrg := &entity.Organization{
+		ID:   "test-org-id",
+		Name: "test-org",
+	}
+	testUser := &entity.User{
+		ID:   "test-user-id",
+		Name: "Test User",
+	}
+
+	mockLsStore.On("GetCurrentUser").Return(testUser, nil)
+	mockLsStore.On("GetOrganizations", (*store.GetOrganizationsOptions)(nil)).Return([]entity.Organization{*testOrg}, nil)
+	mockLsStore.On("UpdateUser", testUser.ID, mock.AnythingOfType("*entity.UpdateUser")).Return(testUser, nil)
+	mockLsStore.On("GetCurrentWorkspaceID").Return("workspace-1", nil)
+	mockLsStore.On("GetActiveOrganizationOrDefault").Return(testOrg, nil)
+
+	cmd := NewCmdLs(mockTerminal, mockLsStore, mockLsStore)
+	cmd.SetOut(outBuffer)
+	cmd.SetErr(errBuffer)
+
+	// Execute the command with the "org" argument
+	cmd.SetArgs([]string{"rubbish"})
+
+	err := cmd.Execute()
+	assert.Error(t, err)
+	assert.Contains(t, errBuffer.String(), `invalid argument`)
+	assert.Contains(t, outBuffer.String(), "Usage:\n")
+}
+
+func TestLsCommand_RunLs_InvalidOrg(t *testing.T) {
+	mockTerminal, outBuffer, _, errBuffer := terminal.NewTestTerminal()
+
+	mockLsStore := new(MockLsStore)
+	testUser := &entity.User{
+		ID:   "test-user-id",
+		Name: "Test User",
+	}
+
+	mockLsStore.On("GetCurrentUser").Return(testUser, nil)
+	mockLsStore.On("GetOrganizations", &store.GetOrganizationsOptions{Name: "invalid-org"}).Return([]entity.Organization{}, nil)
+	mockLsStore.On("UpdateUser", testUser.ID, mock.AnythingOfType("*entity.UpdateUser")).Return(testUser, nil)
+	mockLsStore.On("GetCurrentWorkspaceID").Return("workspace-1", nil)
+
+	cmd := NewCmdLs(mockTerminal, mockLsStore, mockLsStore)
+	cmd.SetOut(outBuffer)
+	cmd.SetErr(errBuffer)
+
+	// Execute the command with an invalid --org flag
+	cmd.SetArgs([]string{"--org", "invalid-org"})
+
+	err := cmd.Execute()
+
+	assert.Error(t, err)
+	assert.Contains(t, errBuffer.String(), "no org found with name invalid-org")
+}
+
+func TestLsCommand_RunLs_WithOrgFlag(t *testing.T) {
+	mockTerminal, outBuffer, verboseBuffer, errBuffer := terminal.NewTestTerminal()
+	mockLsStore := new(MockLsStore)
+	testOrg := &entity.Organization{
+		ID:   "test-org-id",
+		Name: "test-org",
+	}
+	testUser := &entity.User{
+		ID:   "test-user-id",
+		Name: "Test User",
+	}
+	testWorkspaces := []entity.Workspace{
+		{
+			ID:             "workspace-1",
+			Name:           "Workspace 1",
+			CreatedByUserID: "test-user-id",
+			Status:         entity.Running,
+		},
+	}
+
+	mockLsStore.On("GetCurrentUser").Return(testUser, nil)
+	mockLsStore.On("GetOrganizations", (*store.GetOrganizationsOptions)(nil)).Return([]entity.Organization{*testOrg}, nil)
+	mockLsStore.On("GetOrganizations", &store.GetOrganizationsOptions{Name: "test-org"}).Return([]entity.Organization{*testOrg}, nil)
+	mockLsStore.On("GetWorkspaces", "test-org-id", (*store.GetWorkspacesOptions)(nil)).Return(testWorkspaces, nil)
+	mockLsStore.On("UpdateUser", testUser.ID, mock.AnythingOfType("*entity.UpdateUser")).Return(testUser, nil)
+	mockLsStore.On("GetCurrentWorkspaceID").Return("workspace-1", nil)
+
+	cmd := NewCmdLs(mockTerminal, mockLsStore, mockLsStore)
+
+	// Execute the command with the --org flag
+	cmd.SetOut(outBuffer)
+	cmd.SetErr(errBuffer)
+	cmd.SetArgs([]string{"--org", "test-org"})
+
+	err := cmd.Execute()
+	assert.NoError(t, err)
+	assert.Contains(t, verboseBuffer.String(), "You have 1 instances in Org test-org")
+	assert.Contains(t, outBuffer.String(), "Workspace 1")
+}
+
+func TestLsCommand_RunLs_AllFlag(t *testing.T) {
+	mockTerminal, outBuffer, verboseBuffer, errBuffer := terminal.NewTestTerminal()
+
+	mockLsStore := new(MockLsStore)
+	testOrg := &entity.Organization{
+		ID:   "test-org-id",
+		Name: "test-org",
+	}
+	testUser := &entity.User{
+		ID:   "test-user-id",
+		Name: "Test User",
+	}
+	allWorkspaces := []entity.Workspace{
+		{
+			ID:             "workspace-1",
+			Name:           "Workspace 1",
+			CreatedByUserID: "test-user-id",
+			Status:         entity.Running,
+		},
+		{
+			ID:             "workspace-2",
+			Name:           "Workspace 2",
+			CreatedByUserID: "test-user-id-2",
+			Status:         entity.Stopped,
+		},
+	}
+
+	mockLsStore.On("GetCurrentUser").Return(testUser, nil)
+	mockLsStore.On("GetActiveOrganizationOrDefault").Return(testOrg, nil)
+	mockLsStore.On("GetWorkspaces", "test-org-id", (*store.GetWorkspacesOptions)(nil)).Return(allWorkspaces, nil)
+	mockLsStore.On("GetOrganizations", (*store.GetOrganizationsOptions)(nil)).Return([]entity.Organization{*testOrg}, nil)
+	mockLsStore.On("UpdateUser", testUser.ID, mock.AnythingOfType("*entity.UpdateUser")).Return(testUser, nil)
+	mockLsStore.On("GetCurrentWorkspaceID").Return("workspace-1", nil)
+
+	cmd := NewCmdLs(mockTerminal, mockLsStore, mockLsStore)
+	cmd.SetOut(outBuffer)
+	cmd.SetErr(errBuffer)
+	// Execute the command with the --all flag
+	cmd.SetArgs([]string{"--all"})
+
+	err := cmd.Execute()
+	assert.NoError(t, err)
+	assert.Contains(t, verboseBuffer.String(), "You have 1 instances in Org test-org\nno other projects in Org test-org\n%!(EXTRA int=0)Invite a teamate:\n\tbrev invite")
+	assert.Contains(t, outBuffer.String(), " NAME          STATUS   ID           MACHINE \n Workspace 1   RUNNING  workspace-1   (gpu)  \n")
+
+}
+

--- a/pkg/cmd/shell/shell_test.go
+++ b/pkg/cmd/shell/shell_test.go
@@ -1,1 +1,226 @@
 package shell
+
+import (
+	"errors"
+	"os/exec"
+	"testing"
+
+	"github.com/brevdev/brev-cli/pkg/entity"
+	"github.com/brevdev/brev-cli/pkg/store"
+	"github.com/brevdev/brev-cli/pkg/terminal"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+type MockShellStore struct {
+	mock.Mock
+	store.FileStore
+}
+
+func (m *MockShellStore) GetOrganizations(options *store.GetOrganizationsOptions) ([]entity.Organization, error) {
+	args := m.Called(options)
+	return args.Get(0).([]entity.Organization), args.Error(1)
+}
+
+func (m *MockShellStore) GetWorkspaces(organizationID string, options *store.GetWorkspacesOptions) ([]entity.Workspace, error) {
+	args := m.Called(organizationID, options)
+	return args.Get(0).([]entity.Workspace), args.Error(1)
+}
+
+func (m *MockShellStore) StartWorkspace(workspaceID string) (*entity.Workspace, error) {
+	args := m.Called(workspaceID)
+	return args.Get(0).(*entity.Workspace), args.Error(1)
+}
+
+func (m *MockShellStore) GetWorkspace(workspaceID string) (*entity.Workspace, error) {
+	args := m.Called(workspaceID)
+	return args.Get(0).(*entity.Workspace), args.Error(1)
+}
+
+func (m *MockShellStore) GetCurrentUserKeys() (*entity.UserKeys, error) {
+	args := m.Called()
+	return args.Get(0).(*entity.UserKeys), args.Error(1)
+}
+
+func (m *MockShellStore) GetCurrentUser() (*entity.User, error) {
+	args := m.Called()
+	return args.Get(0).(*entity.User), args.Error(1)
+}
+
+func (m *MockShellStore) GetWorkspaceByNameOrIDErr(orgID, workspaceNameOrID string) (*entity.Workspace, error) {
+	args := m.Called(orgID, workspaceNameOrID)
+	return args.Get(0).(*entity.Workspace), args.Error(1)
+}
+
+func (m *MockShellStore) CopyBin(targetBin string) error {
+	args := m.Called(targetBin)
+	return args.Error(0)
+}
+
+func (m *MockShellStore) DoesJetbrainsFilePathExist() (bool, error) {
+	args := m.Called()
+	return args.Get(0).(bool), args.Error(1)
+}
+
+func (m *MockShellStore) DownloadBinary(url string, target string) error {
+	args := m.Called(url, target)
+	return args.Error(0)
+}
+
+func (m *MockShellStore) FileExists(filepath string) (bool, error) {
+	args := m.Called(filepath)
+	return args.Get(0).(bool), args.Error(1)
+}
+
+func (m *MockShellStore) GetActiveOrganizationOrDefault() (*entity.Organization, error) {
+	args := m.Called()
+	return args.Get(0).(*entity.Organization), args.Error(1)
+}
+
+func (m *MockShellStore) GetBrevSSHConfigPath() (string, error) {
+	args := m.Called()
+	return args.Get(0).(string), args.Error(1)
+}
+
+func (m *MockShellStore) GetContextWorkspaces() ([]entity.Workspace, error) {
+	args := m.Called()
+	return args.Get(0).([]entity.Workspace), args.Error(1)
+}
+
+func (m *MockShellStore) WriteBrevSSHConfig(config string) error {
+	args := m.Called(config)
+	return args.Error(0)
+}
+
+func (m *MockShellStore) GetUserSSHConfig() (string, error) {
+	args := m.Called()
+	return args.Get(0).(string), args.Error(1)
+}
+
+func (m *MockShellStore) WriteUserSSHConfig(config string) error {
+	args := m.Called(config)
+	return args.Error(0)
+}
+
+func (m *MockShellStore) GetPrivateKeyPath() (string, error) {
+	args := m.Called()
+	return args.Get(0).(string), args.Error(1)
+}
+
+func (m *MockShellStore) GetUserSSHConfigPath() (string, error) {
+	args := m.Called()
+	return args.Get(0).(string), args.Error(1)
+}
+
+func (m *MockShellStore) GetJetBrainsConfigPath() (string, error) {
+	args := m.Called()
+	return args.Get(0).(string), args.Error(1)
+}
+
+func (m *MockShellStore) GetJetBrainsConfig() (string, error) {
+	args := m.Called()
+	return args.Get(0).(string), args.Error(1)
+}
+
+func (m *MockShellStore) WriteJetBrainsConfig(config string) error {
+	args := m.Called(config)
+	return args.Error(0)
+}
+
+func (m *MockShellStore) GetWSLHostUserSSHConfigPath() (string, error) {
+	args := m.Called()
+	return args.Get(0).(string), args.Error(1)
+}
+
+func (m *MockShellStore) GetWindowsDir() (string, error) {
+	args := m.Called()
+	return args.Get(0).(string), args.Error(1)
+}
+
+func (m *MockShellStore) WriteBrevSSHConfigWSL(config string) error {
+	args := m.Called(config)
+	return args.Error(0)
+}
+
+func (m *MockShellStore) GetFileAsString(path string) (string, error) {
+	args := m.Called(path)
+	return args.Get(0).(string), args.Error(1)
+}
+
+func (m *MockShellStore) GetWSLHostBrevSSHConfigPath() (string, error) {
+	args := m.Called()
+	return args.Get(0).(string), args.Error(1)
+}
+
+func (m *MockShellStore) GetWSLUserSSHConfig() (string, error) {
+	args := m.Called()
+	return args.Get(0).(string), args.Error(1)
+}
+
+func (m *MockShellStore) WriteWSLUserSSHConfig(config string) error {
+	args := m.Called(config)
+	return args.Error(0)
+}
+
+func (m *MockShellStore) GetWorkspaceByNameOrID(orgID string, nameOrID string) ([]entity.Workspace, error) {
+	args := m.Called(orgID, nameOrID)
+	return args.Get(0).([]entity.Workspace), args.Error(1)
+}
+
+func TestNewCmdShell_SSHClientNotInstalled(t *testing.T) {
+	mockTerminal, outBuffer, _, errBuffer := terminal.NewTestTerminal()
+	mockStore := new(MockShellStore)
+
+	cmd := newCmdShellWithDeps(mockTerminal, mockStore, mockStore, func(name string, arg ...string) *exec.Cmd {
+		return exec.Command("false")
+	})
+
+	cmd.SetOut(outBuffer)
+	cmd.SetErr(errBuffer)
+	cmd.SetArgs([]string{"workspace-1"})
+
+	// Run the command
+	err := cmd.Execute()
+
+	// Assertions
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "SSH client is not installed or not available in PATH")
+}
+
+func TestNewCmdShell_SSHClientWorkspaceNotFound(t *testing.T) {
+	mockTerminal, outBuffer, _, errBuffer := terminal.NewTestTerminal()
+	mockStore := new(MockShellStore)
+
+	testUser := &entity.User{
+		ID:   "test-user-id",
+		Name: "Test User",
+	}
+	testOrg := &entity.Organization{
+		ID:   "test-org-id",
+		Name: "test-org",
+	}
+	testWorkspaces := []entity.Workspace{
+		{
+			ID:              "workspace-1",
+			Name:            "Workspace 1",
+			CreatedByUserID: "test-user-id",
+			Status:          entity.Running,
+		},
+	}
+	mockStore.On("GetCurrentUser").Return(testUser, nil)
+	mockStore.On("GetActiveOrganizationOrDefault").Return(testOrg, nil)
+	mockStore.On("GetWorkspaceByNameOrID", testOrg.ID, "workspace-1").Return(testWorkspaces, nil)
+	mockStore.On("GetWorkspace", "workspace-1").Return((*entity.Workspace)(nil), errors.New("workspace not found"))
+
+	cmd := NewCmdShell(mockTerminal, mockStore, mockStore)
+
+	cmd.SetOut(outBuffer)
+	cmd.SetErr(errBuffer)
+	cmd.SetArgs([]string{"workspace-1"})
+
+	err := cmd.Execute()
+
+	assert.Error(t, err)
+	assert.Contains(t, errBuffer.String(), "waiting for instance to be ready")
+	assert.Contains(t, errBuffer.String(), "workspace not found")
+}

--- a/pkg/terminal/terminal.go
+++ b/pkg/terminal/terminal.go
@@ -2,6 +2,7 @@
 package terminal
 
 import (
+	"bytes"
 	"fmt"
 	"io"
 	"os"
@@ -50,12 +51,26 @@ func New() (t *Terminal) {
 	}
 }
 
-func (t *Terminal) SetVerbose(verbose bool) {
-	if verbose {
-		t.out = os.Stdout
-	} else {
-		t.out = silentWriter{}
-	}
+// NewTestTerminal creates a new Terminal instance with buffers for testing
+func NewTestTerminal() (*Terminal, *bytes.Buffer, *bytes.Buffer, *bytes.Buffer) {
+	outBuffer := &bytes.Buffer{}
+	verboseBuffer := &bytes.Buffer{}
+	errBuffer := &bytes.Buffer{}
+
+	return &Terminal{
+		out:     outBuffer,
+		verbose: verboseBuffer,
+		err:     errBuffer,
+		Green:   color.New(color.FgGreen).SprintfFunc(),
+		Yellow:  color.New(color.FgYellow).SprintfFunc(),
+		Red:     color.New(color.FgRed).SprintfFunc(),
+		Blue:    color.New(color.FgBlue).SprintfFunc(),
+		White:   color.New(color.FgWhite, color.Bold).SprintfFunc(),
+	}, outBuffer, verboseBuffer, errBuffer
+}
+
+func (t *Terminal) Out() io.Writer {
+	return t.out
 }
 
 func (t *Terminal) Print(a string) {

--- a/pkg/terminal/terminal.go
+++ b/pkg/terminal/terminal.go
@@ -124,7 +124,7 @@ func (w silentWriter) Write(_ []byte) (n int, err error) {
 }
 
 func (t *Terminal) NewSpinner() *spinner.Spinner {
-	spinner := spinner.New(spinner.CharSets[11], 100*time.Millisecond, spinner.WithWriter(os.Stderr))
+	spinner := spinner.New(spinner.CharSets[11], 100*time.Millisecond, spinner.WithWriter(t.err))
 	err := spinner.Color("cyan", "bold")
 	if err != nil {
 		t.Errprint(err, "")


### PR DESCRIPTION
## Summary

NOTE: The first 3 commits are based off another PR.

Resolves #185 

This PR addresses the issue where running the `brev shell` command in a Docker environment without an installed SSH client would cause a panic. Additionally, it improves the error handling when the specified workspace cannot be found.

## Key changes
1. **SSH Client Check:**
   - Added a check to ensure that the SSH client is installed and available in the system's PATH before attempting to establish a connection. If the SSH client is not found, a clear and actionable error message is returned.

2. **Unit Tests:**
   - Added unit tests to verify the behavior when the SSH client is not installed, ensuring that the error is properly caught and reported.
   - Added a test case to validate that an appropriate error is raised when the workspace is not found.

3. **Code Cleanup:**
   - Performed minor formatting improvements and removed unnecessary whitespace for cleaner code.

## Impact
- Users running `brev shell` in environments without an SSH client will now receive a clear error message guiding them to install the required software.
- Ensures robustness in handling edge cases where the specified workspace cannot be found.

