### PR TITLE
ssh-proxy: attach correct user for host ssh config

### DIFF
--- a/pkg/ssh/sshconfigurer.go
+++ b/pkg/ssh/sshconfigurer.go
@@ -341,16 +341,16 @@ func makeSSHConfigEntryV2(workspace entity.Workspace, privateKeyPath string, clo
 
 	alias = fmt.Sprintf("%s-host", alias)
 	var hostSSHVal string
+	hostport := workspace.GetHostSSHPort()
+	hostuser := workspace.GetHostSSHUser()
 	if workspace.HostSSHProxyHostname == "" {
-		port := workspace.GetHostSSHPort()
-		user = workspace.GetHostSSHUser()
 		entry := SSHConfigEntryV2{
 			Alias:        alias,
 			IdentityFile: privateKeyPath,
-			User:         user,
+			User:         hostuser,
 			Dir:          workspace.GetProjectFolderPath(),
 			HostName:     hostname,
-			Port:         port,
+			Port:         hostport,
 		}
 		tmpl, err := template.New(alias).Parse(SSHConfigEntryTemplateV3)
 		if err != nil {
@@ -365,7 +365,7 @@ func makeSSHConfigEntryV2(workspace entity.Workspace, privateKeyPath string, clo
 		entry := SSHConfigEntryV2{
 			Alias:        alias,
 			IdentityFile: privateKeyPath,
-			User:         user,
+			User:         hostuser,
 			ProxyCommand: proxyCommand,
 			Dir:          workspace.GetProjectFolderPath(),
 		}


### PR DESCRIPTION
For Launchpad, the host user is `nvidia`. This wasn't being properly updated in the ssh config because it uses the ssh proxy which referenced the user variable defined by `GetSSHUser` not `GetHostSSHUser`.