### PR TITLE
Fix the `ls` help syntax to denote org name should be used, not ID

### DIFF
--- a/pkg/cmd/ls/ls.go
+++ b/pkg/cmd/ls/ls.go
@@ -47,7 +47,7 @@ func NewCmdLs(t *terminal.Terminal, loginLsStore LsStore, noLoginLsStore LsStore
 		Example: `
   brev ls
   brev ls orgs
-  brev ls --org <orgid>
+  brev ls --org <name>
 		`,
 		PersistentPostRunE: func(cmd *cobra.Command, args []string) error {
 			if hello.ShouldWeRunOnboardingLSStep(noLoginLsStore) && hello.ShouldWeRunOnboarding(noLoginLsStore) {


### PR DESCRIPTION
The help text indicates to use the `orgid` when listing instances by org, however this failed saying the corresponding org didn't exist. Instead, the org name needed to be supplied for the command to succeed. This change simply fixes the help text to reflect the proper value to use when listing with the `--org` flag.

Help text before change:
```
$ ./brev ls --help                                                                                     #[main]
List instances within your active org. List all instances if no active org is set.

Usage:
  brev ls [flags]

Aliases:
  ls, list

Examples:

  brev ls
  brev ls orgs
  brev ls --org <orgid>


Flags:
      --all          show all workspaces in org
  -h, --help         help for ls
  -o, --org string   organization (will override active org)

Global Flags:
      --user string   non root user to use for per user configuration of commands run as root
      --version       Print version output
```

Failing command:
```
$ ./brev ls orgs
Your organizations:
 NAME          ID                              
 nmitchell-hq  org-2saxhbCMWE3CVXJYLu6YPR0e6qp 
 * launchpad   org-2tDrWXYp4PQMGCHVQtjoEDBXBOr 
 nca-xrndd     org-2uoT5UHyNUSLsGuSVP0hYteAMYR 

Switch orgs:
        brev set <NAME> ex: brev set nmitchell-hq

$ ./brev ls --org org-2saxhbCMWE3CVXJYLu6YPR0e6qp
[error] 
github.com/brevdev/brev-cli/pkg/cmd/ls.NewCmdLs.func3
/Users/nmitchell/git/brev/brev-cli/pkg/cmd/ls/ls.go:99
: [error] 
github.com/brevdev/brev-cli/pkg/cmd/ls.RunLs
/Users/nmitchell/git/brev/brev-cli/pkg/cmd/ls/ls.go:168
: no org found with name org-2saxhbCMWE3CVXJYLu6YPR0e6qp
```

Working command:
```
$ ./brev ls --org nmitchell-hq
No instances in org nmitchell-hq

Start a new instance:
Switch to another org:
        brev set launchpad
```

Updated help text:
```
$ ./brev ls --help                                                                          #[fix-ls-help-org]
List instances within your active org. List all instances if no active org is set.

Usage:
  brev ls [flags]

Aliases:
  ls, list

Examples:

  brev ls
  brev ls orgs
  brev ls --org <name>


Flags:
      --all          show all workspaces in org
  -h, --help         help for ls
  -o, --org string   organization (will override active org)

Global Flags:
      --user string   non root user to use for per user configuration of commands run as root
      --version       Print version output
```