### PR TITLE
Adds `BUILD` and `SHELL` columns to `ls` output

### DIFF
--- a/pkg/cmd/ls/ls.go
+++ b/pkg/cmd/ls/ls.go
@@ -418,13 +418,13 @@ func displayWorkspacesTable(t *terminal.Terminal, workspaces []entity.Workspace,
 		}
 		status := getWorkspaceDisplayStatus(w)
 		instanceString := utilities.GetInstanceString(w)
-		workspaceRow := []table.Row{{fmt.Sprintf("%s %s", w.Name, isShared), getStatusColoredText(t, status), getStatusColoredText(t, string(w.VerbBuildStatus)), getStatusColoredText(t, getSSHDisplayStatus(w)), w.ID, instanceString}}
+		workspaceRow := []table.Row{{fmt.Sprintf("%s %s", w.Name, isShared), getStatusColoredText(t, status), getStatusColoredText(t, string(w.VerbBuildStatus)), getStatusColoredText(t, getShellDisplayStatus(w)), w.ID, instanceString}}
 		ta.AppendRows(workspaceRow)
 	}
 	ta.Render()
 }
 
-func getSSHDisplayStatus(w entity.Workspace) string {
+func getShellDisplayStatus(w entity.Workspace) string {
 	status := entity.NotReady
 	if w.Status == entity.Running && w.VerbBuildStatus == entity.Completed {
 		status = entity.Ready

--- a/pkg/cmd/ls/ls.go
+++ b/pkg/cmd/ls/ls.go
@@ -325,15 +325,6 @@ func (ls Ls) displayWorkspacesAndHelp(org *entity.Organization, otherOrgs []enti
 
 		displayLsResetBreadCrumb(ls.terminal, userWorkspaces)
 		// displayLsConnectBreadCrumb(ls.terminal, userWorkspaces)
-
-		// if !enableSSHCol {
-		// 	ls.terminal.Vprintf(ls.terminal.Green("Or ssh:\n"))
-		// 	for _, v := range userWorkspaces {
-		// 		if v.Status == entity.Running {
-		// 			ls.terminal.Vprintf(ls.terminal.Yellow("\tssh %s\n", v.GetLocalIdentifier()))
-		// 		}
-		// 	}
-		// }
 	}
 }
 
@@ -405,8 +396,6 @@ func displayProjects(t *terminal.Terminal, orgName string, projects []virtualpro
 	}
 }
 
-const enableSSHCol = false
-
 func getBrevTableOptions() table.Options {
 	options := table.OptionsDefault
 	options.DrawBorder = false
@@ -420,10 +409,7 @@ func displayWorkspacesTable(t *terminal.Terminal, workspaces []entity.Workspace,
 	ta := table.NewWriter()
 	ta.SetOutputMirror(os.Stdout)
 	ta.Style().Options = getBrevTableOptions()
-	header := table.Row{"Name", "Status", "ID", "Machine"}
-	if enableSSHCol {
-		header = table.Row{"Name", "Status", "SSH", "ID", "Machine"}
-	}
+	header := table.Row{"Name", "Status", "Build", "Shell", "ID", "Machine"}
 	ta.AppendHeader(header)
 	for _, w := range workspaces {
 		isShared := ""
@@ -432,13 +418,18 @@ func displayWorkspacesTable(t *terminal.Terminal, workspaces []entity.Workspace,
 		}
 		status := getWorkspaceDisplayStatus(w)
 		instanceString := utilities.GetInstanceString(w)
-		workspaceRow := []table.Row{{fmt.Sprintf("%s %s", w.Name, isShared), getStatusColoredText(t, status), w.ID, instanceString}}
-		if enableSSHCol {
-			workspaceRow = []table.Row{{w.Name, getStatusColoredText(t, status), w.GetLocalIdentifier(), w.ID, instanceString}}
-		}
+		workspaceRow := []table.Row{{fmt.Sprintf("%s %s", w.Name, isShared), getStatusColoredText(t, status), getStatusColoredText(t, string(w.VerbBuildStatus)), getStatusColoredText(t, getSSHDisplayStatus(w)), w.ID, instanceString}}
 		ta.AppendRows(workspaceRow)
 	}
 	ta.Render()
+}
+
+func getSSHDisplayStatus(w entity.Workspace) string {
+	status := entity.NotReady
+	if w.Status == entity.Running && w.VerbBuildStatus == entity.Completed {
+		status = entity.Ready
+	}
+	return status
 }
 
 func getWorkspaceDisplayStatus(w entity.Workspace) string {
@@ -480,11 +471,11 @@ func displayProjectsTable(projects []virtualproject.VirtualProject) {
 
 func getStatusColoredText(t *terminal.Terminal, status string) string {
 	switch status {
-	case entity.Running:
+	case entity.Running, entity.Ready, string(entity.Completed):
 		return t.Green(status)
-	case entity.Starting, entity.Deploying, entity.Stopping:
+	case entity.Starting, entity.Deploying, entity.Stopping, string(entity.Building), string(entity.Pending):
 		return t.Yellow(status)
-	case entity.Failure, entity.Deleting, entity.Unhealthy:
+	case entity.Failure, entity.Deleting, entity.Unhealthy, string(entity.CreateFailed):
 		return t.Red(status)
 	default:
 		return status

--- a/pkg/entity/entity.go
+++ b/pkg/entity/entity.go
@@ -259,6 +259,12 @@ const (
 	Unavailable = "UNAVAILABLE"
 )
 
+// SSH Status
+const (
+	NotReady = "NOT READY"
+	Ready    = "READY"
+)
+
 type WorkspaceGroup struct {
 	ID             string `json:"id"`
 	Name           string `json:"name"`

--- a/pkg/entity/entity.go
+++ b/pkg/entity/entity.go
@@ -259,7 +259,7 @@ const (
 	Unavailable = "UNAVAILABLE"
 )
 
-// SSH Status
+// Shell Status
 const (
 	NotReady = "NOT READY"
 	Ready    = "READY"


### PR DESCRIPTION
Adds columns to the `ls` output to display `Build` and `Shell` status.

![image](https://github.com/user-attachments/assets/d25f6660-c245-4f18-ba92-652f2ce58e08)
![image](https://github.com/user-attachments/assets/3e442950-2cb4-4b55-a31a-6d6235d53dbb)
![image](https://github.com/user-attachments/assets/2ba6854b-36d9-43b9-b6d2-9b314db79084)
![image](https://github.com/user-attachments/assets/c618bd5b-404f-4bac-9c67-ff3af9fdffec)
![image](https://github.com/user-attachments/assets/a9192108-23b5-4536-97ac-bbb302918478)
![image](https://github.com/user-attachments/assets/66927c59-0fc2-4932-a4aa-0b189e86f326)
![image](https://github.com/user-attachments/assets/cae86baf-9c00-49c2-818e-82cfbbc59842)

The `Shell` status is determined based on the `Status` and `Build` values. `Shell` will be `READY` when `Status` is `RUNNING` and `Build` is `Completed`. Otherwise it will be `NOT READY`.