### PR TITLE
fix(brev-1192): brev shell not working on lp integration

### DIFF
--- a/pkg/cmd/shell/shell.go
+++ b/pkg/cmd/shell/shell.go
@@ -143,7 +143,7 @@ func waitForSSHToBeAvailable(sshAlias string, s *spinner.Spinner) error {
 	s.Suffix = " waiting for SSH connection to be available"
 	s.Start()
 	for {
-		cmd := exec.Command("ssh", "-o", "ConnectTimeout=3", sshAlias, "echo", " ")
+		cmd := exec.Command("ssh", "-o", "ConnectTimeout=10", sshAlias, "echo", " ")
 		out, err := cmd.CombinedOutput()
 		if err == nil {
 			s.Stop()
@@ -153,7 +153,7 @@ func waitForSSHToBeAvailable(sshAlias string, s *spinner.Spinner) error {
 		outputStr := string(out)
 		stdErr := strings.Split(outputStr, "\n")[1]
 
-		if counter == 120 || !store.SatisfactorySSHErrMessage(stdErr) {
+		if counter == 40 || !store.SatisfactorySSHErrMessage(stdErr) {
 			return breverrors.WrapAndTrace(errors.New("\n" + stdErr))
 		}
 


### PR DESCRIPTION
ticket: https://linear.app/brevidia/issue/BREV-1192/brev-shell-not-working-but-ssh-is
- connect timeout on `wait for ssh to be available` was set to 3 seconds, causing restricted ingress case to timeout even though ssh connection is available