### PR TITLE
docs: Add conda-forge install to instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,14 @@
 
 ## Install the cli
 
+### From conda-forge
+
+To globally install `brev` [from conda-forge](https://github.com/conda-forge/brev-feedstock/) in an isolated environment with [`Pixi`](https://pixi.sh/), run
+
+```
+pixi global install brev
+```
+
 ### MacOS and Linux
 
 ```


### PR DESCRIPTION
Resolves #234

* Add install instructions from conda-forge using `pixi global` to the README. This has the advantage of installing in user space in an isolated environment that can't be broken by other package changes.
   - c.f. https://github.com/conda-forge/brev-feedstock

Through [conda-forge](https://github.com/conda-forge/brev-feedstock/) `brev` is available with shell completions for the following platforms:

| Name | Downloads | Version | Platforms |
| --- | --- | --- | --- |
| [![Conda Recipe](https://img.shields.io/badge/recipe-brev-green.svg)](https://anaconda.org/conda-forge/brev) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/brev.svg)](https://anaconda.org/conda-forge/brev) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/brev.svg)](https://anaconda.org/conda-forge/brev) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/brev.svg)](https://anaconda.org/conda-forge/brev) |

If you want to demo it in a Linux container (where `ca-certificates` doesn't exist yet)

```console
$ docker run --rm -ti ghcr.io/prefix-dev/pixi:latest
root@d287b5e34d8f:/# pixi global install brev
└── brev (installed)
    ├─ dependencies: brev 0.6.310
    └─ exposes: brev
root@d287b5e34d8f:/# apt update && apt install -y ca-certificates
root@d287b5e34d8f:/# brev login

   ▸     Starting Login

Enter your email: <email>
Browser link: https://api.ngc.nvidia.com/login?code=SECRET

Alternatively, get CLI Command ("Login via CLI"):  https://brev.nvidia.com/profile?login=cli

   ▸    Press Enter to login via browser
```