### PR TITLE
vscode ext ID mapping to cursor ext ID mapping for brev open cursor

### DIFF
--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -120,7 +120,19 @@ func IsCursorExtensionInstalled(extensionID string) (bool, error) {
 	if err != nil {
 		return false, breverrors.WrapAndTrace(err)
 	}
-	return strings.Contains(string(out), extensionID), nil
+
+	// Check for the original extension ID
+	if strings.Contains(string(out), extensionID) {
+		return true, nil
+	}
+
+	// Check for Cursor-specific extension ID mappings
+	cursorEquivalent := mapVSCodeToCursorExtension(extensionID)
+	if cursorEquivalent != "" && strings.Contains(string(out), cursorEquivalent) {
+		return true, nil
+	}
+
+	return false, nil
 }
 
 func InstallWindsurfExtension(extensionID string) error {
@@ -267,4 +279,13 @@ var commonWindsurfPaths = []string{
 	"/snap/bin/windsurf",
 	"/usr/local/share/windsurf/bin/windsurf",
 	"/usr/share/windsurf/bin/windsurf",
+}
+
+// mapVSCodeToCursorExtension maps VSCode extension IDs to their Cursor equivalents
+func mapVSCodeToCursorExtension(vscodeExtensionID string) string {
+	cursorMappings := map[string]string{
+		"ms-vscode-remote.remote-ssh": "anysphere.remote-ssh",
+		// Add more mappings here as we discover them
+	}
+	return cursorMappings[vscodeExtensionID]
 }

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -21,3 +21,13 @@ func TestBasePath(t *testing.T) {
 	b := RemoveFileExtenstion(x)
 	assert.Equal(t, "abc/setup", b)
 }
+
+func TestMapVSCodeToCursorExtension(t *testing.T) {
+	// Test known mapping
+	result := mapVSCodeToCursorExtension("ms-vscode-remote.remote-ssh")
+	assert.Equal(t, "anysphere.remote-ssh", result)
+
+	// Test unknown extension (should return empty string)
+	result = mapVSCodeToCursorExtension("unknown.extension")
+	assert.Equal(t, "", result)
+}


### PR DESCRIPTION
This creates a mapping between the expected vscode remote-ssh extension to the proper remote-ssh extension in cursor. Fixes this:
```
% brev open gpu_instance cursor                 
finding your instance...
⣟ Instance is ready. Opening Cursor 🤙 
Couldn't install the necessary Cursor extension automatically.
Error: 0 errors occurred:
	
	Please install Cursor and the following Cursor extension: ms-vscode-remote.remote-ssh.

Hit enter when finished: █
```

Previously:
- The code checks if ms-vscode-remote.remote-ssh is installed in Cursor → Not found (because Cursor uses a different ID)
- Tries to install ms-vscode-remote.remote-ssh → Succeeds (the extension gets installed)
- Checks again for ms-vscode-remote.remote-ssh → Still not found (because it's listed as anysphere.remote-ssh)
- Show error message with "0 errors occurred" (all CLI commands succeeded, but extension appeared missing)
- 
https://linear.app/nvidia/issue/BREV-1721/brev-open-command-not-working