### PR TITLE
dynamically set workspace home dir based on SSHUser

### DIFF
--- a/pkg/cmd/open/open.go
+++ b/pkg/cmd/open/open.go
@@ -179,7 +179,10 @@ func runOpenCommand(t *terminal.Terminal, tstore OpenStore, wsIDOrName string, s
 		return breverrors.WorkspaceNotRunning{Status: workspace.Status}
 	}
 
-	projPath := workspace.GetProjectFolderPath()
+	projPath, err := workspace.GetProjectFolderPath()
+	if err != nil {
+		return breverrors.WrapAndTrace(err)
+	}
 	if directory != "" {
 		projPath = directory
 	}

--- a/pkg/entity/entity.go
+++ b/pkg/entity/entity.go
@@ -449,7 +449,8 @@ func (w Workspace) GetProjectFolderPath() string {
 	if MapContainsKey(LegacyWorkspaceGroups, w.WorkspaceGroupID) {
 		prefix = "/home/brev/workspace"
 	} else {
-		prefix = "/home/ubuntu"
+		sshUser := w.GetSSHUser()
+		prefix = "/home/" + sshUser
 	}
 	var folderName string
 	if w.IDEConfig.DefaultWorkingDir != "" { //nolint:gocritic // i like if else

--- a/pkg/entity/entity.go
+++ b/pkg/entity/entity.go
@@ -444,18 +444,20 @@ func MapContainsKey[K comparable, V any](m map[K]V, key K) bool {
 	return ok
 }
 
-func (w Workspace) GetProjectFolderPath() string {
+func (w Workspace) GetProjectFolderPath() (string, error) {
 	var prefix string
 	if MapContainsKey(LegacyWorkspaceGroups, w.WorkspaceGroupID) {
 		prefix = "/home/brev/workspace"
 	} else {
-		sshUser := w.GetSSHUser()
-		prefix = "/home/" + sshUser
+		if w.SSHUser == "" {
+			return "", fmt.Errorf("workspace %s has empty SSH user (workspace may not be running)", w.ID)
+		}
+		prefix = "/home/" + w.SSHUser
 	}
 	var folderName string
 	if w.IDEConfig.DefaultWorkingDir != "" { //nolint:gocritic // i like if else
 		if path.IsAbs(w.IDEConfig.DefaultWorkingDir) {
-			return w.IDEConfig.DefaultWorkingDir
+			return w.IDEConfig.DefaultWorkingDir, nil
 		} else {
 			folderName = w.IDEConfig.DefaultWorkingDir
 		}
@@ -472,13 +474,13 @@ func (w Workspace) GetProjectFolderPath() string {
 				}
 			}
 		} else {
-			return prefix
+			return prefix, nil
 		}
 	} else {
-		return prefix
+		return prefix, nil
 	}
 
-	return filepath.Join(prefix, folderName) // TODO make workspace dir configurable
+	return filepath.Join(prefix, folderName), nil // TODO make workspace dir configurable
 }
 
 func GetDefaultProjectFolderNameFromRepo(repo string) string {

--- a/pkg/ssh/sshconfigurer.go
+++ b/pkg/ssh/sshconfigurer.go
@@ -281,12 +281,16 @@ func makeSSHConfigEntryV2(workspace entity.Workspace, privateKeyPath string, clo
 	privateKeyPath = "\"" + privateKeyPath + "\""
 	if workspace.IsLegacy() {
 		proxyCommand := makeProxyCommand(workspace.ID)
+		projPath, err := workspace.GetProjectFolderPath()
+		if err != nil {
+			return "", breverrors.WrapAndTrace(err)
+		}
 		entry := SSHConfigEntryV2{
 			Alias:        alias,
 			IdentityFile: privateKeyPath,
 			User:         "brev",
 			ProxyCommand: proxyCommand,
-			Dir:          workspace.GetProjectFolderPath(),
+			Dir:          projPath,
 		}
 		tmpl, err := template.New(alias).Parse(SSHConfigEntryTemplateV2)
 		if err != nil {
@@ -304,11 +308,15 @@ func makeSSHConfigEntryV2(workspace entity.Workspace, privateKeyPath string, clo
 	hostname := workspace.GetHostname()
 	if workspace.SSHProxyHostname == "" {
 		port := workspace.GetSSHPort()
+		projPath, err := workspace.GetProjectFolderPath()
+		if err != nil {
+			return "", breverrors.WrapAndTrace(err)
+		}
 		entry := SSHConfigEntryV2{
 			Alias:        alias,
 			IdentityFile: privateKeyPath,
 			User:         user,
-			Dir:          workspace.GetProjectFolderPath(),
+			Dir:          projPath,
 			HostName:     hostname,
 			Port:         port,
 		}
@@ -322,12 +330,16 @@ func makeSSHConfigEntryV2(workspace entity.Workspace, privateKeyPath string, clo
 		}
 	} else {
 		proxyCommand := makeCloudflareSSHProxyCommand(cloudflaredBinaryPath, workspace.SSHProxyHostname)
+		projPath, err := workspace.GetProjectFolderPath()
+		if err != nil {
+			return "", breverrors.WrapAndTrace(err)
+		}
 		entry := SSHConfigEntryV2{
 			Alias:        alias,
 			IdentityFile: privateKeyPath,
 			User:         user,
 			ProxyCommand: proxyCommand,
-			Dir:          workspace.GetProjectFolderPath(),
+			Dir:          projPath,
 		}
 		tmpl, err := template.New(alias).Parse(SSHConfigEntryTemplateV2)
 		if err != nil {
@@ -344,11 +356,15 @@ func makeSSHConfigEntryV2(workspace entity.Workspace, privateKeyPath string, clo
 	hostport := workspace.GetHostSSHPort()
 	hostuser := workspace.GetHostSSHUser()
 	if workspace.HostSSHProxyHostname == "" {
+		projPath, err := workspace.GetProjectFolderPath()
+		if err != nil {
+			return "", breverrors.WrapAndTrace(err)
+		}
 		entry := SSHConfigEntryV2{
 			Alias:        alias,
 			IdentityFile: privateKeyPath,
 			User:         hostuser,
-			Dir:          workspace.GetProjectFolderPath(),
+			Dir:          projPath,
 			HostName:     hostname,
 			Port:         hostport,
 		}
@@ -362,12 +378,16 @@ func makeSSHConfigEntryV2(workspace entity.Workspace, privateKeyPath string, clo
 		}
 	} else {
 		proxyCommand := makeCloudflareSSHProxyCommand(cloudflaredBinaryPath, workspace.HostSSHProxyHostname)
+		projPath, err := workspace.GetProjectFolderPath()
+		if err != nil {
+			return "", breverrors.WrapAndTrace(err)
+		}
 		entry := SSHConfigEntryV2{
 			Alias:        alias,
 			IdentityFile: privateKeyPath,
 			User:         hostuser,
 			ProxyCommand: proxyCommand,
-			Dir:          workspace.GetProjectFolderPath(),
+			Dir:          projPath,
 		}
 		tmpl, err := template.New(alias).Parse(SSHConfigEntryTemplateV2)
 		if err != nil {


### PR DESCRIPTION
`/home/ubuntu` was hardcoded as the workspace so even if you connected as a different user you would be dropped into the `/home/ubuntu` homedir with a bunch of permissions errors. This fix uses `Workspace.SSHUser` instead of hardcoding "ubuntu"

https://linear.app/nvidia/issue/BREV-1649/brev-open-is-not-opening-to-proper-user-shadeform