### PR TITLE
Add space before email in hello CLI

### DIFF
--- a/pkg/cmd/hello/hello.go
+++ b/pkg/cmd/hello/hello.go
@@ -125,7 +125,7 @@ func RunOnboarding(t *terminal.Terminal, user *entity.User, store HelloStore) er
 	s := "Hey " + GetFirstName(user.Name) + " 👋\n"
 
 	s += "\n\nI'm excited you installed NVIDIA Brev. Let's get you started!\n"
-	s += "\nbtw, reach out if you need anything"
+	s += "\nbtw, reach out if you need anything "
 	s += t.Yellow("brev-support@nvidia.com")
 
 	s += "\n\nNVIDIA Brev is a dev tool for creating and sharing GPU accelerated instances"


### PR DESCRIPTION
While exploring the `brev` CLI I noticed there's a space missing between the `brev-support@nvidia.com` email and the text beforehand. This PR adds a space. 

<img width="1402" height="582" alt="Screenshot 2025-09-30 at 9 57 53 AM" src="https://github.com/user-attachments/assets/62a5fc65-6087-4b4f-b495-ad301c7d5c31" />