### PR TITLE
chore: remove project mentions and stale goroot path

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -21,7 +21,6 @@
   ],
   "go.lintOnSave": "workspace",
   "go.testTimeout": "240s",
-  "go.goroot": "/home/ubuntu/.asdf/installs/golang//go",
   "[go][go.mod]": {
     "editor.codeActionsOnSave": {
       "source.organizeImports": "explicit"

--- a/pkg/cmd/create/doc.md
+++ b/pkg/cmd/create/doc.md
@@ -199,9 +199,6 @@ Connect to running workspace:
  solidity-nextjs-starter           1
  akka-http-quickstart-scala        1
 
-Join a project:
-	brev start new-docs
-
 ```
 
 join the project new-docs

--- a/pkg/cmd/ls/ls.go
+++ b/pkg/cmd/ls/ls.go
@@ -368,18 +368,6 @@ func (ls Ls) RunUser(_ bool) error {
 func (ls Ls) ShowAllWorkspaces(org *entity.Organization, otherOrgs []entity.Organization, user *entity.User, allWorkspaces []entity.Workspace, gpuLookup map[string]string) {
 	userWorkspaces := store.FilterForUserWorkspaces(allWorkspaces, user.ID)
 	ls.displayWorkspacesAndHelp(org, otherOrgs, userWorkspaces, allWorkspaces, gpuLookup)
-
-	projects := virtualproject.NewVirtualProjects(allWorkspaces)
-
-	var unjoinedProjects []virtualproject.VirtualProject
-	for _, p := range projects {
-		wks := p.GetUserWorkspaces(user.ID)
-		if len(wks) == 0 {
-			unjoinedProjects = append(unjoinedProjects, p)
-		}
-	}
-
-	displayProjects(ls.terminal, org.Name, unjoinedProjects)
 }
 
 func (ls Ls) ShowUserWorkspaces(org *entity.Organization, otherOrgs []entity.Organization, user *entity.User, allWorkspaces []entity.Workspace, gpuLookup map[string]string) {
@@ -395,7 +383,7 @@ func (ls Ls) displayWorkspacesAndHelp(org *entity.Organization, otherOrgs []enti
 			ls.terminal.Vprintf("%s", ls.terminal.Green("See teammates' instances:\n"))
 			ls.terminal.Vprintf("%s", ls.terminal.Yellow("\tbrev ls --all\n"))
 		} else {
-			ls.terminal.Vprintf("%s", ls.terminal.Green("Start a new instance:\n"))
+			ls.terminal.Vprintf("%s", ls.terminal.Green("Create a new instance:\n"))
 		}
 		if len(otherOrgs) > 1 {
 			ls.terminal.Vprintf("%s", ls.terminal.Green("Switch to another org:\n"))
@@ -409,7 +397,6 @@ func (ls Ls) displayWorkspacesAndHelp(org *entity.Organization, otherOrgs []enti
 		fmt.Print("\n")
 
 		displayLsResetBreadCrumb(ls.terminal, userWorkspaces)
-		// displayLsConnectBreadCrumb(ls.terminal, userWorkspaces)
 	}
 }
 

--- a/pkg/cmd/start/doc.md
+++ b/pkg/cmd/start/doc.md
@@ -199,9 +199,6 @@ Connect to running workspace:
  solidity-nextjs-starter           1
  akka-http-quickstart-scala        1
 
-Join a project:
-	brev start new-docs
-
 ```
 
 join the project new-docs

--- a/pkg/cmd/status/doc.md
+++ b/pkg/cmd/status/doc.md
@@ -199,9 +199,6 @@ Connect to running workspace:
  solidity-nextjs-starter           1
  akka-http-quickstart-scala        1
 
-Join a project:
-	brev start new-docs
-
 ```
 
 join the project new-docs


### PR DESCRIPTION
## Summary
- Remove "Join a project" references from doc.md files (create, start, status)
- Remove virtual project display logic from `brev ls` output
- Change "Start a new instance" to "Create a new instance" in ls help text
- Remove stale goroot path from .vscode/settings.json