### PR TITLE
fix(auth): refresh on 401 and stop writing bogus refresh tokens

### DIFF
--- a/pkg/auth/auth.go
+++ b/pkg/auth/auth.go
@@ -146,6 +146,13 @@ func (t Auth) GetFreshAccessTokenOrNil() (string, error) {
 		return "", nil
 	}
 
+	// Older CLI versions stored the literal string "auto-login" when
+	// `brev login --token` had no real refresh token to save. Treat it as
+	// absent so we do not attempt to exchange it with the IdP and fail.
+	if tokens.RefreshToken == autoLoginSentinel {
+		tokens.RefreshToken = ""
+	}
+
 	// should always at least have access token?
 	if tokens.AccessToken == "" {
 		breverrors.GetDefaultErrorReporter().ReportMessage("access token is an empty string but shouldn't be")
@@ -154,7 +161,13 @@ func (t Auth) GetFreshAccessTokenOrNil() (string, error) {
 	if err != nil {
 		return "", breverrors.WrapAndTrace(err)
 	}
-	if !isAccessTokenValid && tokens.RefreshToken != "" {
+	if !isAccessTokenValid {
+		if tokens.RefreshToken == "" {
+			// Access token is expired and we have no refresh token. Returning
+			// the expired token here would just cause a 401 on the next API
+			// call; return empty so callers can prompt for re-login instead.
+			return "", nil
+		}
 		tokens, err = t.getNewTokensWithRefreshOrNil(tokens.RefreshToken)
 		if err != nil {
 			return "", breverrors.WrapAndTrace(err)
@@ -162,8 +175,6 @@ func (t Auth) GetFreshAccessTokenOrNil() (string, error) {
 		if tokens == nil {
 			return "", nil
 		}
-	} else if tokens.RefreshToken == "" && tokens.AccessToken == "" {
-		return "", nil
 	}
 	return tokens.AccessToken, nil
 }
@@ -197,22 +208,39 @@ func shouldLogin() (bool, error) {
 	return trimmed == "y" || trimmed == "", nil
 }
 
+// autoLoginSentinel is a legacy value older CLI versions stored in place of
+// a real token when `brev login --token` was used. It is not a valid token of
+// any kind; treat it as "absent" on read.
+const autoLoginSentinel = "auto-login"
+
 func (t Auth) LoginWithToken(token string) error {
 	valid, err := isAccessTokenValid(token)
 	if err != nil {
 		return breverrors.WrapAndTrace(err)
 	}
 	if valid {
+		// The token is a self-contained JWT access token with no accompanying
+		// refresh token. Previously we stored the string "auto-login" in the
+		// RefreshToken slot; when the access token expired the refresh path
+		// then attempted to exchange that sentinel with the IdP, which always
+		// failed, logging the user out every time the short-lived access
+		// token aged out. Store an empty RefreshToken instead so the refresh
+		// path correctly recognizes there is nothing to refresh and prompts
+		// for a fresh login exactly once.
+		fmt.Fprintln(os.Stderr, "Note: tokens from --token cannot be refreshed; re-run `brev login` when the session expires.")
 		err := t.authStore.SaveAuthTokens(entity.AuthTokens{
 			AccessToken:  token,
-			RefreshToken: "auto-login",
+			RefreshToken: "",
 		})
 		if err != nil {
 			return breverrors.WrapAndTrace(err)
 		}
 	} else {
+		// The token is not a JWT, assume it is a refresh token. The access
+		// token slot is filled with the sentinel so the first API call
+		// triggers a refresh to populate a real access token.
 		err := t.authStore.SaveAuthTokens(entity.AuthTokens{
-			AccessToken:  "auto-login",
+			AccessToken:  autoLoginSentinel,
 			RefreshToken: token,
 		})
 		if err != nil {

--- a/pkg/store/http.go
+++ b/pkg/store/http.go
@@ -104,7 +104,7 @@ func (s *AuthHTTPStore) SetForbiddenStatusRetryHandler(handler func() error) err
 	}
 	attemptsThresh := 1
 	s.authHTTPClient.restyClient.OnAfterResponse(func(c *resty.Client, r *resty.Response) error {
-		if r.StatusCode() == http.StatusForbidden && r.Request.Attempt < attemptsThresh+1 {
+		if isAuthFailure(r.StatusCode()) && r.Request.Attempt < attemptsThresh+1 {
 			err := handler()
 			if err != nil {
 				return breverrors.WrapAndTrace(err)
@@ -117,12 +117,20 @@ func (s *AuthHTTPStore) SetForbiddenStatusRetryHandler(handler func() error) err
 			if e != nil {
 				return false
 			}
-			return r.StatusCode() == http.StatusForbidden
+			return isAuthFailure(r.StatusCode())
 		})
 	s.authHTTPClient.restyClient.SetRetryCount(attemptsThresh)
 
 	s.isRefreshTokenHandlerSet = true
 	return nil
+}
+
+// isAuthFailure reports whether an HTTP status code indicates the caller's
+// credentials are missing, invalid, or expired. Both 401 Unauthorized and
+// 403 Forbidden can signal an expired access token from Brev's APIs, so we
+// treat both as triggers for the refresh-and-retry path.
+func isAuthFailure(code int) bool {
+	return code == http.StatusUnauthorized || code == http.StatusForbidden
 }
 
 type AuthHTTPClient struct {


### PR DESCRIPTION
## Problem

Users report being logged out of `brev-cli` multiple times per hour, forcing repeated `brev login --token $TOKEN`. Two independent bugs in the auth flow combined to produce this.

### Bug 1: `LoginWithToken` writes a bogus refresh token

`pkg/auth/auth.go` `LoginWithToken` (before this PR):

```go
if valid {
    err := t.authStore.SaveAuthTokens(entity.AuthTokens{
        AccessToken:  token,
        RefreshToken: "auto-login",   // <- literal string, not a token
    })
}
```

When a user runs `brev login --token $JWT` (e.g. the snippet from https://brev.nvidia.com/settings/cli), the CLI saves the JWT as the access token and the **literal string `"auto-login"`** as the refresh token.

Later, when the short-lived access token expires, `GetFreshAccessTokenOrNil` sees `RefreshToken != ""` and calls `oauth.GetNewAuthTokensWithRefresh("auto-login")`. That always fails (the IdP doesn’t recognize the sentinel), so the user is bumped back to re-login. With typical NVIDIA KAS access-token TTLs, that happens roughly hourly.

### Bug 2: auth-failure retry only fires on 403, not 401

`pkg/store/http.go` `SetForbiddenStatusRetryHandler` (before this PR) installed a refresh-and-retry handler that only triggered on `http.StatusForbidden` (403). APIs returning `401 Unauthorized` — the more standard response for expired credentials — bypassed the hook entirely and surfaced as a hard failure on the first such response, even when the refresh token was still valid.

## Fix

**`pkg/auth/auth.go`**

- `LoginWithToken` no longer writes `"auto-login"` as the refresh token for JWT input. It stores an empty `RefreshToken` and prints a one-line notice on stderr so the user knows the session will not auto-renew.
- `GetFreshAccessTokenOrNil` normalizes the legacy `"auto-login"` sentinel to `""` on read, so existing `~/.brev/credentials.json` files from older CLI versions benefit from the fix without re-running `brev login --token`.
- When the access token is expired **and** there is no refresh token, `GetFreshAccessTokenOrNil` now returns `""` instead of the expired JWT. Callers prompt for re-login cleanly instead of shipping a doomed request.

**`pkg/store/http.go`**

- The refresh-and-retry handler now fires on both 401 and 403, via a small `isAuthFailure(code int) bool` helper. The public function name (`SetForbiddenStatusRetryHandler`) is left unchanged to avoid touching callers; the comment on `isAuthFailure` documents the broadened semantics.

## What this does and does not fix

**Fixes:** the hourly logout loop caused by the bogus-refresh + JWT-expiry interaction, and unhandled 401s that skipped the refresh path.

**Does not fix:** `brev login --token` still produces a non-refreshable session, because the website currently hands out a raw access JWT rather than a refresh token. Step 2 of the larger plan is a server-side change to `brev.nvidia.com/settings/cli` so it issues a refresh token (or a short-lived exchange code) that the CLI can swap for `{access, refresh}`. That is out of scope for this PR.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./pkg/store/... ./pkg/auth/...`
- [x] `go test ./pkg/auth/...`
- [ ] Manual: `brev login --token $JWT`, wait for the access token to expire, verify the CLI prompts for re-login once (not per-call) and that subsequent calls with a real `{access, refresh}` pair auto-refresh without re-prompting.
- [ ] Manual: verify that an API call returning 401 now triggers the refresh handler and retries once, rather than failing immediately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)