### PR TITLE
feat(auth): refresh access token proactively before expiry

### DIFF
--- a/pkg/auth/auth.go
+++ b/pkg/auth/auth.go
@@ -4,10 +4,13 @@ import (
 	"bufio"
 	"errors"
 	"fmt"
+	"net"
+	"net/url"
 	"os"
 	"os/exec"
 	"runtime"
 	"strings"
+	"time"
 
 	"github.com/brevdev/brev-cli/pkg/config"
 	"github.com/brevdev/brev-cli/pkg/entity"
@@ -16,6 +19,12 @@ import (
 	"github.com/golang-jwt/jwt/v5"
 	"github.com/pkg/browser"
 )
+
+// refreshBeforeExpiry is how far in advance of access-token expiration the
+// CLI refreshes. Using a window larger than typical request RTTs avoids 401
+// round-trips at the tail of a token's life, at the cost of refreshing a
+// small number of still-valid tokens.
+const refreshBeforeExpiry = 5 * time.Minute
 
 type LoginAuth struct {
 	Auth
@@ -161,22 +170,121 @@ func (t Auth) GetFreshAccessTokenOrNil() (string, error) {
 	if err != nil {
 		return "", breverrors.WrapAndTrace(err)
 	}
-	if !isAccessTokenValid {
+
+	// Trigger a refresh when the token is invalid OR when it is still valid
+	// but close enough to expiry that the next API call is likely to race
+	// the exp boundary. The proactive branch is tolerant of refresh failure:
+	// if the IdP is briefly unreachable, fall back to the (still-valid)
+	// current access token rather than logging the user out.
+	expiringSoon := isAccessTokenValid && tokens.RefreshToken != "" && accessTokenExpiresSoon(tokens)
+	if !isAccessTokenValid || expiringSoon {
 		if tokens.RefreshToken == "" {
 			// Access token is expired and we have no refresh token. Returning
 			// the expired token here would just cause a 401 on the next API
 			// call; return empty so callers can prompt for re-login instead.
 			return "", nil
 		}
-		tokens, err = t.getNewTokensWithRefreshOrNil(tokens.RefreshToken)
-		if err != nil {
-			return "", breverrors.WrapAndTrace(err)
+		newTokens, refreshErr := t.getNewTokensWithRefreshOrNil(tokens.RefreshToken)
+		if refreshErr != nil {
+			if expiringSoon {
+				// Current token still validates; swallow the transient
+				// failure and try again on the next call.
+				return tokens.AccessToken, nil
+			}
+			return "", breverrors.WrapAndTrace(refreshErr)
 		}
-		if tokens == nil {
+		if newTokens == nil {
 			return "", nil
 		}
+		tokens = newTokens
 	}
 	return tokens.AccessToken, nil
+}
+
+// accessTokenExpiresSoon reports whether the stored access token's
+// expiration is within refreshBeforeExpiry of now. It prefers the persisted
+// AccessTokenExp field (written by populateTokenTimestamps on save) and
+// falls back to decoding the access JWT for files written by older CLI
+// versions that never persisted the claim.
+func accessTokenExpiresSoon(tokens *entity.AuthTokens) bool {
+	var exp time.Time
+	if tokens.AccessTokenExp != nil {
+		exp = *tokens.AccessTokenExp
+	} else {
+		exp, _ = accessTokenClaims(tokens.AccessToken)
+	}
+	if exp.IsZero() {
+		return false
+	}
+	return time.Until(exp) < refreshBeforeExpiry
+}
+
+// accessTokenClaims parses the access JWT without signature verification
+// and returns its exp and iat claims. Missing or malformed claims are
+// returned as the zero time.Time; the caller is responsible for guarding
+// with IsZero().
+func accessTokenClaims(token string) (exp, iat time.Time) {
+	if token == "" {
+		return time.Time{}, time.Time{}
+	}
+	parser := jwt.Parser{}
+	ptoken, _, err := parser.ParseUnverified(token, jwt.MapClaims{})
+	if err != nil {
+		return time.Time{}, time.Time{}
+	}
+	claims, ok := ptoken.Claims.(jwt.MapClaims)
+	if !ok {
+		return time.Time{}, time.Time{}
+	}
+	if v, ok := claims["exp"].(float64); ok {
+		exp = time.Unix(int64(v), 0)
+	}
+	if v, ok := claims["iat"].(float64); ok {
+		iat = time.Unix(int64(v), 0)
+	}
+	return exp, iat
+}
+
+// populateTokenTimestamps fills in AccessTokenExp and IssuedAt from the
+// access JWT when they are not already set. Safe to call on any AuthTokens
+// value; missing or non-JWT access tokens leave the fields nil.
+func populateTokenTimestamps(tokens *entity.AuthTokens) {
+	if tokens == nil || tokens.AccessToken == "" {
+		return
+	}
+	exp, iat := accessTokenClaims(tokens.AccessToken)
+	if tokens.AccessTokenExp == nil && !exp.IsZero() {
+		tokens.AccessTokenExp = &exp
+	}
+	if tokens.IssuedAt == nil && !iat.IsZero() {
+		tokens.IssuedAt = &iat
+	}
+}
+
+// isTransientRefreshError reports whether an error from the OAuth refresh
+// call is a transient network condition (timeout, connection refused,
+// DNS failure, etc.) as opposed to an authoritative rejection of the
+// refresh token by the IdP. Transient errors should not force the user to
+// re-login.
+func isTransientRefreshError(err error) bool {
+	if err == nil {
+		return false
+	}
+	var urlErr *url.Error
+	if errors.As(err, &urlErr) {
+		if urlErr.Timeout() {
+			return true
+		}
+	}
+	var netErr net.Error
+	if errors.As(err, &netErr) && netErr.Timeout() {
+		return true
+	}
+	// DNS / connection-refused / TLS handshake errors surface as url.Error
+	// wrapping an *net.OpError. Treat connection-level failures as
+	// transient: the refresh token is probably fine, the network isn't.
+	var opErr *net.OpError
+	return errors.As(err, &opErr)
 }
 
 // Prompts for login and returns tokens, and saves to store
@@ -228,22 +336,22 @@ func (t Auth) LoginWithToken(token string) error {
 		// path correctly recognizes there is nothing to refresh and prompts
 		// for a fresh login exactly once.
 		fmt.Fprintln(os.Stderr, "Note: tokens from --token cannot be refreshed; re-run `brev login` when the session expires.")
-		err := t.authStore.SaveAuthTokens(entity.AuthTokens{
+		tokens := entity.AuthTokens{
 			AccessToken:  token,
 			RefreshToken: "",
-		})
-		if err != nil {
+		}
+		populateTokenTimestamps(&tokens)
+		if err := t.authStore.SaveAuthTokens(tokens); err != nil {
 			return breverrors.WrapAndTrace(err)
 		}
 	} else {
 		// The token is not a JWT, assume it is a refresh token. The access
 		// token slot is filled with the sentinel so the first API call
 		// triggers a refresh to populate a real access token.
-		err := t.authStore.SaveAuthTokens(entity.AuthTokens{
+		if err := t.authStore.SaveAuthTokens(entity.AuthTokens{
 			AccessToken:  autoLoginSentinel,
 			RefreshToken: token,
-		})
-		if err != nil {
+		}); err != nil {
 			return breverrors.WrapAndTrace(err)
 		}
 	}
@@ -350,13 +458,20 @@ func (t Auth) getSavedTokensOrNil() (*entity.AuthTokens, error) {
 // gets new access and refresh token or returns nil if refresh token expired, and updates store
 func (t Auth) getNewTokensWithRefreshOrNil(refreshToken string) (*entity.AuthTokens, error) {
 	tokens, err := t.oauth.GetNewAuthTokensWithRefresh(refreshToken)
-	// TODO 2 handle if 403 invalid grant
-	// https://stackoverflow.com/questions/57383523/how-to-detect-when-an-oauth2-refresh-token-expired
 	if err != nil {
 		if strings.Contains(err.Error(), "not implemented") {
 			return nil, nil
 		}
-		return nil, breverrors.WrapAndTrace(err)
+		if isTransientRefreshError(err) {
+			// Network hiccup; do not clear the user's session. Surface the
+			// error so the caller can decide whether to swallow it (when
+			// the current access token is still valid) or propagate it.
+			return nil, breverrors.WrapAndTrace(fmt.Errorf("could not reach auth provider to refresh session: %w", err))
+		}
+		// Definitive rejection from the IdP. Tell the user in plain
+		// language rather than burying it in a stack trace.
+		fmt.Fprintln(os.Stderr, "Your brev session could not be refreshed; re-run `brev login`.")
+		return nil, nil
 	}
 	if tokens == nil {
 		return nil, nil
@@ -364,6 +479,7 @@ func (t Auth) getNewTokensWithRefreshOrNil(refreshToken string) (*entity.AuthTok
 	if tokens.RefreshToken == "" {
 		tokens.RefreshToken = refreshToken
 	}
+	populateTokenTimestamps(tokens)
 
 	err = t.authStore.SaveAuthTokens(*tokens)
 	if err != nil {

--- a/pkg/auth/auth.go
+++ b/pkg/auth/auth.go
@@ -146,6 +146,13 @@ func (t Auth) GetFreshAccessTokenOrNil() (string, error) {
 		return "", nil
 	}
 
+	// Older CLI versions stored the literal string "auto-login" when
+	// `brev login --token` had no real refresh token to save. Treat it as
+	// absent so we do not attempt to exchange it with the IdP and fail.
+	if tokens.RefreshToken == autoLoginSentinel {
+		tokens.RefreshToken = ""
+	}
+
 	// should always at least have access token?
 	if tokens.AccessToken == "" {
 		breverrors.GetDefaultErrorReporter().ReportMessage("access token is an empty string but shouldn't be")
@@ -154,7 +161,13 @@ func (t Auth) GetFreshAccessTokenOrNil() (string, error) {
 	if err != nil {
 		return "", breverrors.WrapAndTrace(err)
 	}
-	if !isAccessTokenValid && tokens.RefreshToken != "" {
+	if !isAccessTokenValid {
+		if tokens.RefreshToken == "" {
+			// Access token is expired and we have no refresh token. Returning
+			// the expired token here would just cause a 401 on the next API
+			// call; return empty so callers can prompt for re-login instead.
+			return "", nil
+		}
 		tokens, err = t.getNewTokensWithRefreshOrNil(tokens.RefreshToken)
 		if err != nil {
 			return "", breverrors.WrapAndTrace(err)
@@ -162,8 +175,6 @@ func (t Auth) GetFreshAccessTokenOrNil() (string, error) {
 		if tokens == nil {
 			return "", nil
 		}
-	} else if tokens.RefreshToken == "" && tokens.AccessToken == "" {
-		return "", nil
 	}
 	return tokens.AccessToken, nil
 }
@@ -197,22 +208,39 @@ func shouldLogin() (bool, error) {
 	return trimmed == "y" || trimmed == "", nil
 }
 
+// autoLoginSentinel is a legacy value older CLI versions stored in place of
+// a real token when `brev login --token` was used. It is not a valid token of
+// any kind; treat it as "absent" on read.
+const autoLoginSentinel = "auto-login"
+
 func (t Auth) LoginWithToken(token string) error {
 	valid, err := isAccessTokenValid(token)
 	if err != nil {
 		return breverrors.WrapAndTrace(err)
 	}
 	if valid {
+		// The token is a self-contained JWT access token with no accompanying
+		// refresh token. Previously we stored the string "auto-login" in the
+		// RefreshToken slot; when the access token expired the refresh path
+		// then attempted to exchange that sentinel with the IdP, which always
+		// failed, logging the user out every time the short-lived access
+		// token aged out. Store an empty RefreshToken instead so the refresh
+		// path correctly recognizes there is nothing to refresh and prompts
+		// for a fresh login exactly once.
+		fmt.Fprintln(os.Stderr, "Note: tokens from --token cannot be refreshed; re-run `brev login` when the session expires.")
 		err := t.authStore.SaveAuthTokens(entity.AuthTokens{
 			AccessToken:  token,
-			RefreshToken: "auto-login",
+			RefreshToken: "",
 		})
 		if err != nil {
 			return breverrors.WrapAndTrace(err)
 		}
 	} else {
+		// The token is not a JWT, assume it is a refresh token. The access
+		// token slot is filled with the sentinel so the first API call
+		// triggers a refresh to populate a real access token.
 		err := t.authStore.SaveAuthTokens(entity.AuthTokens{
-			AccessToken:  "auto-login",
+			AccessToken:  autoLoginSentinel,
 			RefreshToken: token,
 		})
 		if err != nil {

--- a/pkg/entity/entity.go
+++ b/pkg/entity/entity.go
@@ -27,6 +27,14 @@ var LegacyWorkspaceGroups = map[string]bool{
 type AuthTokens struct {
 	AccessToken  string `json:"access_token"`
 	RefreshToken string `json:"refresh_token"`
+	// AccessTokenExp and IssuedAt are populated from the access JWT's `exp`
+	// and `iat` claims when available. They let the CLI refresh proactively
+	// before the access token expires, and let UX surfaces like `brev
+	// status` display session lifetime without re-parsing the JWT. Both are
+	// optional: files written by older CLI versions lack these fields, and
+	// tokens whose JWTs do not carry the claims will leave them nil.
+	AccessTokenExp *time.Time `json:"access_token_exp,omitempty"`
+	IssuedAt       *time.Time `json:"issued_at,omitempty"`
 }
 
 type IDEConfig struct {

--- a/pkg/store/http.go
+++ b/pkg/store/http.go
@@ -104,7 +104,7 @@ func (s *AuthHTTPStore) SetForbiddenStatusRetryHandler(handler func() error) err
 	}
 	attemptsThresh := 1
 	s.authHTTPClient.restyClient.OnAfterResponse(func(c *resty.Client, r *resty.Response) error {
-		if r.StatusCode() == http.StatusForbidden && r.Request.Attempt < attemptsThresh+1 {
+		if isAuthFailure(r.StatusCode()) && r.Request.Attempt < attemptsThresh+1 {
 			err := handler()
 			if err != nil {
 				return breverrors.WrapAndTrace(err)
@@ -117,12 +117,20 @@ func (s *AuthHTTPStore) SetForbiddenStatusRetryHandler(handler func() error) err
 			if e != nil {
 				return false
 			}
-			return r.StatusCode() == http.StatusForbidden
+			return isAuthFailure(r.StatusCode())
 		})
 	s.authHTTPClient.restyClient.SetRetryCount(attemptsThresh)
 
 	s.isRefreshTokenHandlerSet = true
 	return nil
+}
+
+// isAuthFailure reports whether an HTTP status code indicates the caller's
+// credentials are missing, invalid, or expired. Both 401 Unauthorized and
+// 403 Forbidden can signal an expired access token from Brev's APIs, so we
+// treat both as triggers for the refresh-and-retry path.
+func isAuthFailure(code int) bool {
+	return code == http.StatusUnauthorized || code == http.StatusForbidden
 }
 
 type AuthHTTPClient struct {


### PR DESCRIPTION
## Stacked on #359

This PR is stacked on https://github.com/brevdev/brev-cli/pull/359 (Step 1: the reactive refresh + `"auto-login"` sentinel cleanup). Because #359 is not merged yet, the diff for this PR includes its two commits too. Once #359 lands, the base of this PR will be rebased onto `main` and the diff will shrink to just the Step 3 commit.

Relates to https://github.com/brevdev/brev-cli/issues/360 (Step 2, server-side).

## Problem

After #359, the CLI no longer silently wedges itself with `"auto-login"` as a refresh token, and it retries on 401. But the refresh is still reactive — it only fires after an API call returns 401. Two consequences:

1. **Every call that races the `exp` boundary pays a round-trip.** The doomed 401 request, the refresh, then the retry. For short-TTL KAS access tokens that's common.
2. **Transient network failures look like hard auth failures.** If `api.ngc.nvidia.com` is momentarily slow or unreachable during the refresh call, the user is pushed through an error path as if their refresh credential had been rejected, even though the still-valid access token in hand would have answered the next call just fine.

## Fix

**`pkg/entity/entity.go`**

- `AuthTokens` gains optional `AccessTokenExp *time.Time` and `IssuedAt *time.Time` fields (both `omitempty`). These are populated from the access JWT's `exp` and `iat` claims at save time, so the CLI doesn't have to re-parse the JWT on every call to check expiry.
- Backward-compatible: credentials files written by older CLI versions simply don't have these fields; the CLI falls back to parsing the JWT live for those files.

**`pkg/auth/auth.go`**

- New const `refreshBeforeExpiry = 5 * time.Minute`. If the access token is valid *and* expires within this window, the CLI refreshes before making the next call. Five minutes comfortably exceeds typical request RTTs (so we don't race) without refreshing so aggressively that we burn the IdP's refresh budget.
- `GetFreshAccessTokenOrNil` now handles three cases:
  - access token valid and not expiring soon → return it
  - access token invalid → refresh; propagate errors (today's behavior)
  - access token valid but expiring soon → attempt refresh; **on error, fall back to the still-valid access token**. The user isn't logged out because of a 200ms network blip.
- `getNewTokensWithRefreshOrNil` now classifies refresh errors. A small `isTransientRefreshError` helper uses `errors.As` to identify `url.Error` / `net.Error` timeouts and `net.OpError` connection failures. Transient failures are wrapped with a plain-language message; authoritative rejections from the IdP produce a single stderr line ("re-run `brev login`") rather than a stack trace, which is the experience the user who filed the original report was asking for.
- `populateTokenTimestamps` is called on both the `LoginWithToken` save path and the refresh save path, so the new fields are always kept in sync with the current access token.

## What this does and does not fix

**Fixes:** the extra-round-trip cost on near-exp access tokens, and the UX regression where momentary network failures force re-login. With this PR the CLI will only prompt for `brev login` when the IdP has *actually* rejected the refresh credential.

**Does not fix:** the `brev login --token` path still produces a non-refreshable session, because the `/settings/cli` webpage hands out a raw JWT rather than a refresh credential. That is the server-side change tracked in #360.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./pkg/auth/... ./pkg/store/... ./pkg/entity/...`
- [x] `go test ./pkg/auth/...`
- [ ] Manual: set a very short access-token TTL on a test account, use the CLI for a few minutes, confirm refresh happens ~5 min before expiry with no 401 round-trip.
- [ ] Manual: block outbound to `api.ngc.nvidia.com` for ~1 minute mid-session; confirm the CLI continues answering calls with the current access token and resumes refresh on the next call, rather than prompting for re-login.
- [ ] Manual: revoke a refresh token server-side; confirm the CLI prints the single-line stderr prompt and exits cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)