### PR TITLE
Brev 8959/fix unix socket len macos

### DIFF
--- a/pkg/cmd/shell/shell.go
+++ b/pkg/cmd/shell/shell.go
@@ -1,9 +1,12 @@
 package shell
 
 import (
+	"bytes"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
+	"strings"
 	"time"
 
 	nodev1 "buf.build/gen/go/brevdev/devplane/protocolbuffers/go/devplaneapi/v1"
@@ -203,8 +206,9 @@ func runSSH(sshAlias string, host bool) error {
 		cmd = fmt.Sprintf("%s && ssh -t %s 'DIR=$(readlink -f /proc/1/cwd 2>/dev/null || pwd); cd \"$DIR\" || echo \"Warning: Could not access container directory\" >&2; exec -l ${SHELL:-/bin/sh}'", sshAgentEval, sshAlias)
 	}
 
+	var stderrBuf bytes.Buffer
 	sshCmd := exec.Command("bash", "-c", cmd) //nolint:gosec //cmd is user input
-	sshCmd.Stderr = os.Stderr
+	sshCmd.Stderr = io.MultiWriter(os.Stderr, &stderrBuf)
 	sshCmd.Stdout = os.Stdout
 	sshCmd.Stdin = os.Stdin
 
@@ -215,6 +219,13 @@ func runSSH(sshAlias string, host bool) error {
 
 	err = sshCmd.Run()
 	if err != nil {
+		stderrStr := stderrBuf.String()
+		if strings.Contains(stderrStr, "unix_listener") || strings.Contains(stderrStr, "path too long") {
+			fmt.Fprintf(os.Stderr, "\nbrev shell failed: SSH ControlPath socket path is too long for this system.\n")
+			fmt.Fprintf(os.Stderr, "Fix: run 'brev refresh' to regenerate your SSH config with the updated ControlPath.\n")
+		} else {
+			fmt.Fprintf(os.Stderr, "\nbrev shell failed. If the above SSH error is unclear, try running 'brev refresh' and reconnecting.\n")
+		}
 		return breverrors.WrapAndTrace(err)
 	}
 	return nil

--- a/pkg/ssh/ssh.go
+++ b/pkg/ssh/ssh.go
@@ -39,7 +39,7 @@ const workspaceSSHConfigTemplate = `Host {{ .Host }}
   ForwardAgent yes
   AddKeysToAgent yes
   ControlMaster auto
-  ControlPath ~/.ssh/brev-%C
+  ControlPath ~/.ssh/brev-control-%C
   ControlPersist 10m
   RemoteCommand cd {{ .Dir }}; $SHELL
 

--- a/pkg/ssh/ssh.go
+++ b/pkg/ssh/ssh.go
@@ -39,7 +39,7 @@ const workspaceSSHConfigTemplate = `Host {{ .Host }}
   ForwardAgent yes
   AddKeysToAgent yes
   ControlMaster auto
-  ControlPath ~/.ssh/brev-control-%r@%h-%p
+  ControlPath ~/.ssh/brev-%C
   ControlPersist 10m
   RemoteCommand cd {{ .Dir }}; $SHELL
 

--- a/pkg/ssh/sshconfigurer.go
+++ b/pkg/ssh/sshconfigurer.go
@@ -305,7 +305,7 @@ const SSHConfigEntryTemplateV2 = `Host {{ .Alias }}
   ForwardAgent yes
   RequestTTY yes
   ControlMaster auto
-  ControlPath ~/.ssh/brev-control-%r@%h-%p
+  ControlPath ~/.ssh/brev-%C
   ControlPersist 10m
 {{ if .RunRemoteCMD }}
   RemoteCommand cd {{ .Dir }}; $SHELL
@@ -325,7 +325,7 @@ const SSHConfigEntryTemplateV3 = `Host {{ .Alias }}
   ForwardAgent yes
   RequestTTY yes
   ControlMaster auto
-  ControlPath ~/.ssh/brev-control-%r@%h-%p
+  ControlPath ~/.ssh/brev-%C
   ControlPersist 10m
   Port {{ .Port }}
 {{ if .RunRemoteCMD }}

--- a/pkg/ssh/sshconfigurer.go
+++ b/pkg/ssh/sshconfigurer.go
@@ -305,7 +305,7 @@ const SSHConfigEntryTemplateV2 = `Host {{ .Alias }}
   ForwardAgent yes
   RequestTTY yes
   ControlMaster auto
-  ControlPath ~/.ssh/brev-%C
+  ControlPath ~/.ssh/brev-control-%C
   ControlPersist 10m
 {{ if .RunRemoteCMD }}
   RemoteCommand cd {{ .Dir }}; $SHELL
@@ -325,7 +325,7 @@ const SSHConfigEntryTemplateV3 = `Host {{ .Alias }}
   ForwardAgent yes
   RequestTTY yes
   ControlMaster auto
-  ControlPath ~/.ssh/brev-%C
+  ControlPath ~/.ssh/brev-control-%C
   ControlPersist 10m
   Port {{ .Port }}
 {{ if .RunRemoteCMD }}

--- a/pkg/ssh/sshconfigurer_test.go
+++ b/pkg/ssh/sshconfigurer_test.go
@@ -151,7 +151,7 @@ Host %s
   ForwardAgent yes
   RequestTTY yes
   ControlMaster auto
-  ControlPath ~/.ssh/brev-%%C
+  ControlPath ~/.ssh/brev-control-%%C
   ControlPersist 10m
   Port 22
 
@@ -168,7 +168,7 @@ Host %s-host
   ForwardAgent yes
   RequestTTY yes
   ControlMaster auto
-  ControlPath ~/.ssh/brev-%%C
+  ControlPath ~/.ssh/brev-control-%%C
   ControlPersist 10m
   Port 22
 
@@ -185,7 +185,7 @@ Host %s
   ForwardAgent yes
   RequestTTY yes
   ControlMaster auto
-  ControlPath ~/.ssh/brev-%%C
+  ControlPath ~/.ssh/brev-control-%%C
   ControlPersist 10m
   Port 22
 
@@ -202,7 +202,7 @@ Host %s-host
   ForwardAgent yes
   RequestTTY yes
   ControlMaster auto
-  ControlPath ~/.ssh/brev-%%C
+  ControlPath ~/.ssh/brev-control-%%C
   ControlPersist 10m
   Port 22
 
@@ -323,7 +323,7 @@ func Test_makeSSHConfigEntryV2(t *testing.T) { //nolint:funlen // test
   ForwardAgent yes
   RequestTTY yes
   ControlMaster auto
-  ControlPath ~/.ssh/brev-%C
+  ControlPath ~/.ssh/brev-control-%C
   ControlPersist 10m
   Port 20
 
@@ -340,7 +340,7 @@ Host testName2-host
   ForwardAgent yes
   RequestTTY yes
   ControlMaster auto
-  ControlPath ~/.ssh/brev-%C
+  ControlPath ~/.ssh/brev-control-%C
   ControlPersist 10m
   Port 2022
 
@@ -378,7 +378,7 @@ Host testName2-host
   ForwardAgent yes
   RequestTTY yes
   ControlMaster auto
-  ControlPath ~/.ssh/brev-%C
+  ControlPath ~/.ssh/brev-control-%C
   ControlPersist 10m
   Port 22
 
@@ -395,7 +395,7 @@ Host testName2-host
   ForwardAgent yes
   RequestTTY yes
   ControlMaster auto
-  ControlPath ~/.ssh/brev-%C
+  ControlPath ~/.ssh/brev-control-%C
   ControlPersist 10m
   Port 22
 
@@ -434,7 +434,7 @@ Host testName2-host
   ForwardAgent yes
   RequestTTY yes
   ControlMaster auto
-  ControlPath ~/.ssh/brev-%C
+  ControlPath ~/.ssh/brev-control-%C
   ControlPersist 10m
   Port 2022
 
@@ -451,7 +451,7 @@ Host testName2-host
   ForwardAgent yes
   RequestTTY yes
   ControlMaster auto
-  ControlPath ~/.ssh/brev-%C
+  ControlPath ~/.ssh/brev-control-%C
   ControlPersist 10m
   Port 22
 
@@ -488,7 +488,7 @@ Host testName2-host
   ForwardAgent yes
   RequestTTY yes
   ControlMaster auto
-  ControlPath ~/.ssh/brev-%C
+  ControlPath ~/.ssh/brev-control-%C
   ControlPersist 10m
 
 `,
@@ -524,7 +524,7 @@ Host testName2-host
   ForwardAgent yes
   RequestTTY yes
   ControlMaster auto
-  ControlPath ~/.ssh/brev-%C
+  ControlPath ~/.ssh/brev-control-%C
   ControlPersist 10m
 
 `,
@@ -564,7 +564,7 @@ Host testName2-host
   ForwardAgent yes
   RequestTTY yes
   ControlMaster auto
-  ControlPath ~/.ssh/brev-%C
+  ControlPath ~/.ssh/brev-control-%C
   ControlPersist 10m
 
 Host testName2-host
@@ -580,7 +580,7 @@ Host testName2-host
   ForwardAgent yes
   RequestTTY yes
   ControlMaster auto
-  ControlPath ~/.ssh/brev-%C
+  ControlPath ~/.ssh/brev-control-%C
   ControlPersist 10m
 
 `,
@@ -808,7 +808,7 @@ Host testName1
   ForwardAgent yes
   RequestTTY yes
   ControlMaster auto
-  ControlPath ~/.ssh/brev-%C
+  ControlPath ~/.ssh/brev-control-%C
   ControlPersist 10m
   Port 22
 
@@ -825,7 +825,7 @@ Host testName1-host
   ForwardAgent yes
   RequestTTY yes
   ControlMaster auto
-  ControlPath ~/.ssh/brev-%C
+  ControlPath ~/.ssh/brev-control-%C
   ControlPersist 10m
   Port 22
 
@@ -874,7 +874,7 @@ Host testName1
   ForwardAgent yes
   RequestTTY yes
   ControlMaster auto
-  ControlPath ~/.ssh/brev-%C
+  ControlPath ~/.ssh/brev-control-%C
   ControlPersist 10m
   Port 22
 
@@ -891,7 +891,7 @@ Host testName1-host
   ForwardAgent yes
   RequestTTY yes
   ControlMaster auto
-  ControlPath ~/.ssh/brev-%C
+  ControlPath ~/.ssh/brev-control-%C
   ControlPersist 10m
   Port 22
 
@@ -911,7 +911,7 @@ Host testName1
   ForwardAgent yes
   RequestTTY yes
   ControlMaster auto
-  ControlPath ~/.ssh/brev-%C
+  ControlPath ~/.ssh/brev-control-%C
   ControlPersist 10m
   Port 22
 
@@ -928,7 +928,7 @@ Host testName1-host
   ForwardAgent yes
   RequestTTY yes
   ControlMaster auto
-  ControlPath ~/.ssh/brev-%C
+  ControlPath ~/.ssh/brev-control-%C
   ControlPersist 10m
   Port 22
 

--- a/pkg/ssh/sshconfigurer_test.go
+++ b/pkg/ssh/sshconfigurer_test.go
@@ -151,7 +151,7 @@ Host %s
   ForwardAgent yes
   RequestTTY yes
   ControlMaster auto
-  ControlPath ~/.ssh/brev-control-%%r@%%h-%%p
+  ControlPath ~/.ssh/brev-%%C
   ControlPersist 10m
   Port 22
 
@@ -168,7 +168,7 @@ Host %s-host
   ForwardAgent yes
   RequestTTY yes
   ControlMaster auto
-  ControlPath ~/.ssh/brev-control-%%r@%%h-%%p
+  ControlPath ~/.ssh/brev-%%C
   ControlPersist 10m
   Port 22
 
@@ -185,7 +185,7 @@ Host %s
   ForwardAgent yes
   RequestTTY yes
   ControlMaster auto
-  ControlPath ~/.ssh/brev-control-%%r@%%h-%%p
+  ControlPath ~/.ssh/brev-%%C
   ControlPersist 10m
   Port 22
 
@@ -202,7 +202,7 @@ Host %s-host
   ForwardAgent yes
   RequestTTY yes
   ControlMaster auto
-  ControlPath ~/.ssh/brev-control-%%r@%%h-%%p
+  ControlPath ~/.ssh/brev-%%C
   ControlPersist 10m
   Port 22
 
@@ -323,7 +323,7 @@ func Test_makeSSHConfigEntryV2(t *testing.T) { //nolint:funlen // test
   ForwardAgent yes
   RequestTTY yes
   ControlMaster auto
-  ControlPath ~/.ssh/brev-control-%r@%h-%p
+  ControlPath ~/.ssh/brev-%C
   ControlPersist 10m
   Port 20
 
@@ -340,7 +340,7 @@ Host testName2-host
   ForwardAgent yes
   RequestTTY yes
   ControlMaster auto
-  ControlPath ~/.ssh/brev-control-%r@%h-%p
+  ControlPath ~/.ssh/brev-%C
   ControlPersist 10m
   Port 2022
 
@@ -378,7 +378,7 @@ Host testName2-host
   ForwardAgent yes
   RequestTTY yes
   ControlMaster auto
-  ControlPath ~/.ssh/brev-control-%r@%h-%p
+  ControlPath ~/.ssh/brev-%C
   ControlPersist 10m
   Port 22
 
@@ -395,7 +395,7 @@ Host testName2-host
   ForwardAgent yes
   RequestTTY yes
   ControlMaster auto
-  ControlPath ~/.ssh/brev-control-%r@%h-%p
+  ControlPath ~/.ssh/brev-%C
   ControlPersist 10m
   Port 22
 
@@ -434,7 +434,7 @@ Host testName2-host
   ForwardAgent yes
   RequestTTY yes
   ControlMaster auto
-  ControlPath ~/.ssh/brev-control-%r@%h-%p
+  ControlPath ~/.ssh/brev-%C
   ControlPersist 10m
   Port 2022
 
@@ -451,7 +451,7 @@ Host testName2-host
   ForwardAgent yes
   RequestTTY yes
   ControlMaster auto
-  ControlPath ~/.ssh/brev-control-%r@%h-%p
+  ControlPath ~/.ssh/brev-%C
   ControlPersist 10m
   Port 22
 
@@ -488,7 +488,7 @@ Host testName2-host
   ForwardAgent yes
   RequestTTY yes
   ControlMaster auto
-  ControlPath ~/.ssh/brev-control-%r@%h-%p
+  ControlPath ~/.ssh/brev-%C
   ControlPersist 10m
 
 `,
@@ -524,7 +524,7 @@ Host testName2-host
   ForwardAgent yes
   RequestTTY yes
   ControlMaster auto
-  ControlPath ~/.ssh/brev-control-%r@%h-%p
+  ControlPath ~/.ssh/brev-%C
   ControlPersist 10m
 
 `,
@@ -564,7 +564,7 @@ Host testName2-host
   ForwardAgent yes
   RequestTTY yes
   ControlMaster auto
-  ControlPath ~/.ssh/brev-control-%r@%h-%p
+  ControlPath ~/.ssh/brev-%C
   ControlPersist 10m
 
 Host testName2-host
@@ -580,7 +580,7 @@ Host testName2-host
   ForwardAgent yes
   RequestTTY yes
   ControlMaster auto
-  ControlPath ~/.ssh/brev-control-%r@%h-%p
+  ControlPath ~/.ssh/brev-%C
   ControlPersist 10m
 
 `,
@@ -808,7 +808,7 @@ Host testName1
   ForwardAgent yes
   RequestTTY yes
   ControlMaster auto
-  ControlPath ~/.ssh/brev-control-%r@%h-%p
+  ControlPath ~/.ssh/brev-%C
   ControlPersist 10m
   Port 22
 
@@ -825,7 +825,7 @@ Host testName1-host
   ForwardAgent yes
   RequestTTY yes
   ControlMaster auto
-  ControlPath ~/.ssh/brev-control-%r@%h-%p
+  ControlPath ~/.ssh/brev-%C
   ControlPersist 10m
   Port 22
 
@@ -874,7 +874,7 @@ Host testName1
   ForwardAgent yes
   RequestTTY yes
   ControlMaster auto
-  ControlPath ~/.ssh/brev-control-%r@%h-%p
+  ControlPath ~/.ssh/brev-%C
   ControlPersist 10m
   Port 22
 
@@ -891,7 +891,7 @@ Host testName1-host
   ForwardAgent yes
   RequestTTY yes
   ControlMaster auto
-  ControlPath ~/.ssh/brev-control-%r@%h-%p
+  ControlPath ~/.ssh/brev-%C
   ControlPersist 10m
   Port 22
 
@@ -911,7 +911,7 @@ Host testName1
   ForwardAgent yes
   RequestTTY yes
   ControlMaster auto
-  ControlPath ~/.ssh/brev-control-%r@%h-%p
+  ControlPath ~/.ssh/brev-%C
   ControlPersist 10m
   Port 22
 
@@ -928,7 +928,7 @@ Host testName1-host
   ForwardAgent yes
   RequestTTY yes
   ControlMaster auto
-  ControlPath ~/.ssh/brev-control-%r@%h-%p
+  ControlPath ~/.ssh/brev-%C
   ControlPersist 10m
   Port 22
 


### PR DESCRIPTION
## Problem

`ControlPath` for SSH ControlMaster is a Unix domain socket. The previous format `~/.ssh/brev-control-%r@%h-%p` built the path from remote user, host, and port. On long hostnames (e.g. some AWS EC2 names such as `ec2-3-90-240-200.compute-1.amazonaws.com`), the path could exceed **104 characters**—macOS’s limit for Unix socket paths—leading to:

`unix_listener: path "..." too long for Unix domain socket`

`brev shell` did not surface this well: it failed with only an SSH exit code and no clear message.

## Changes

### ControlPath (`ssh.go`, `sshconfigurer.go`, `sshconfigurer_test.go`)

- **Before:** `ControlPath ~/.ssh/brev-control-%r@%h-%p`
- **After:** `ControlPath ~/.ssh/brev-control-%C`

`%C` is SSH’s 40‑character SHA1 of the connection parameters, so the path no longer depends on hostname length. It remains unique per connection, same as `%r@%h-%p`, with no other behavior change.

### Error handling (`pkg/cmd/shell/shell.go`)

- SSH `stderr` is handled with `io.MultiWriter` so output still appears on the terminal in real time, while failures can be explained.
- If the error matches a ControlPath / socket path length problem, the message tells users to run `brev refresh` so their SSH config is regenerated.
- For other SSH failures, a short generic hint also points to `brev refresh`.

Users who have not run `brev refresh` and still have the old `ControlPath` in their SSH config will see a clear explanation instead of a silent or opaque failure.