### PR TITLE
fix(BRE2-931): make set case insensitive

### DIFF
--- a/pkg/ssh/sshconfigurer_test.go
+++ b/pkg/ssh/sshconfigurer_test.go
@@ -607,7 +607,7 @@ func TestSanitizeNodeName(t *testing.T) {
 		want  string
 	}{
 		{"My GPU Box", "my-gpu-box"},
-		{"pratik-ec2", "pratik-ec2"},
+		{"my-ec2", "my-ec2"},
 		{"already-clean", "already-clean"},
 		{"UPPER CASE", "upper-case"},
 		{"special!@#chars", "special-chars"},

--- a/pkg/store/organization.go
+++ b/pkg/store/organization.go
@@ -158,7 +158,7 @@ func (s AuthHTTPStore) GetOrganizations(options *GetOrganizationsOptions) ([]ent
 
 	filteredOrgs := []entity.Organization{}
 	for _, o := range orgs {
-		if o.Name == options.Name {
+		if strings.EqualFold(o.Name, options.Name) {
 			filteredOrgs = append(filteredOrgs, o)
 		}
 	}

--- a/pkg/store/organization_test.go
+++ b/pkg/store/organization_test.go
@@ -104,6 +104,42 @@ func TestGetActiveOrganization_APIKeyUsesCredentialOrgNameWhenAvailable(t *testi
 	assert.Equal(t, expected.Name, org.Name)
 }
 
+func TestGetOrganizationsFiltersNameCaseInsensitive(t *testing.T) {
+	fs := MakeMockAuthHTTPStore()
+	httpmock.ActivateNonDefault(fs.authHTTPClient.restyClient.GetClient())
+	defer httpmock.DeactivateAndReset()
+
+	expected := []entity.Organization{{
+		ID:   "1",
+		Name: "TEST",
+	}}
+	orgs := []entity.Organization{
+		expected[0],
+		{
+			ID:   "2",
+			Name: "Other",
+		},
+	}
+	res, err := httpmock.NewJsonResponder(200, orgs)
+	if !assert.Nil(t, err) {
+		return
+	}
+	url := fmt.Sprintf("%s/%s", fs.authHTTPClient.restyClient.BaseURL, orgPath)
+	httpmock.RegisterResponder("GET", url, res)
+
+	org, err := fs.GetOrganizations(&GetOrganizationsOptions{Name: "test"})
+	if !assert.Nil(t, err) {
+		return
+	}
+	if !assert.NotNil(t, org) {
+		return
+	}
+
+	if !assert.Equal(t, expected, org) {
+		return
+	}
+}
+
 func TestCreateOrganization(t *testing.T) {
 	fs := MakeMockAuthHTTPStore()
 	httpmock.ActivateNonDefault(fs.authHTTPClient.restyClient.GetClient())


### PR DESCRIPTION
brev-cli is not case insensitive, but the UI is case when doing duplicate checks