### PR TITLE
fix: brev-open-command-triggers-two-concurrent-interactive-login-prompts

### DIFF
--- a/pkg/cmd/open/open.go
+++ b/pkg/cmd/open/open.go
@@ -110,6 +110,7 @@ type OpenStore interface {
 	GetWorkspace(workspaceID string) (*entity.Workspace, error)
 	GetWindowsDir() (string, error)
 	IsWorkspace() (bool, error)
+	GetAccessToken() (string, error)
 }
 
 func NewCmdOpen(t *terminal.Terminal, store OpenStore, noLoginStartStore OpenStore) *cobra.Command {
@@ -280,6 +281,9 @@ func handleSetDefault(t *terminal.Terminal, editorType string) error {
 
 // Fetch workspace info, then open code editor
 func runOpenCommand(t *terminal.Terminal, tstore OpenStore, wsIDOrName string, setupDoneString string, directory string, host bool, editorType string) error { //nolint:funlen,gocyclo // define brev command
+	if _, err := tstore.GetAccessToken(); err != nil {
+		return breverrors.WrapAndTrace(err)
+	}
 	// todo check if workspace is stopped and start if it if it is stopped
 	fmt.Println("finding your instance...")
 	res := refresh.RunRefreshAsync(tstore)


### PR DESCRIPTION
### **Problem**
`brev open` triggered two concurrent interactive login prompts when the user's access token was missing or expired. Both `RunRefreshAsync` and `ResolveWorkspaceOrNode` were kicking off independent auth flows in parallel, causing stdin to be misread which results in “declined to login” error.

### **Fix**
Force a single, synchronous access-token acquisition at the very top of runOpenCommand before any concurrent work starts. If the user is logged out, this triggers the interactive login once; downstream calls reuse the cached token.