### PR TITLE
fix(BREV-9479): inline lifecycle script body when deploying launchable via CLI

### DIFF
--- a/pkg/cmd/gpucreate/gpucreate.go
+++ b/pkg/cmd/gpucreate/gpucreate.go
@@ -421,7 +421,7 @@ func inlineLaunchableLifeCycleScript(gpuCreateStore GPUCreateStore, launchableID
 		return nil
 	}
 	attr := info.BuildRequest.VMBuild.LifeCycleScriptAttr
-	if attr == nil || attr.ID == "" || attr.Script != "" {
+	if attr == nil || attr.ID == "" {
 		return nil
 	}
 	resp, err := gpuCreateStore.GetLaunchableLifeCycleScript(launchableID, attr.ID)

--- a/pkg/cmd/gpucreate/gpucreate.go
+++ b/pkg/cmd/gpucreate/gpucreate.go
@@ -105,6 +105,7 @@ type GPUCreateStore interface {
 	DeleteWorkspace(workspaceID string) (*entity.Workspace, error)
 	GetAllInstanceTypesWithWorkspaceGroups(orgID string) (*gpusearch.AllInstanceTypesResponse, error)
 	GetLaunchable(launchableID string) (*store.LaunchableResponse, error)
+	GetLaunchableLifeCycleScript(launchableID, scriptID string) (*store.LifeCycleScriptResponse, error)
 	RedeemCouponCode(organizationID string, code string) (*store.RedeemCouponCodeResponse, error)
 }
 
@@ -394,6 +395,11 @@ func fetchAndDisplayLaunchable(gpuCreateStore GPUCreateStore, t *terminal.Termin
 		return nil, fmt.Errorf("failed to fetch launchable %q: %w", launchableID, err)
 	}
 
+	// Inline the script body; the launchable GET only returns its id.
+	if err := inlineLaunchableLifeCycleScript(gpuCreateStore, launchableID, info); err != nil {
+		return nil, err
+	}
+
 	t.Vprintf("Deploying launchable: %q\n", info.Name)
 	if info.Description != "" {
 		t.Vprintf("Description: %s\n", info.Description)
@@ -408,6 +414,24 @@ func fetchAndDisplayLaunchable(gpuCreateStore GPUCreateStore, t *terminal.Termin
 	t.Vprintf("Build mode: %s\n\n", buildMode)
 
 	return info, nil
+}
+
+func inlineLaunchableLifeCycleScript(gpuCreateStore GPUCreateStore, launchableID string, info *store.LaunchableResponse) error {
+	if info == nil || info.BuildRequest.VMBuild == nil {
+		return nil
+	}
+	attr := info.BuildRequest.VMBuild.LifeCycleScriptAttr
+	if attr == nil || attr.ID == "" || attr.Script != "" {
+		return nil
+	}
+	resp, err := gpuCreateStore.GetLaunchableLifeCycleScript(launchableID, attr.ID)
+	if err != nil {
+		return fmt.Errorf("failed to fetch lifecycle script %q for launchable %q: %w", attr.ID, launchableID, err)
+	}
+	if resp != nil && resp.Attrs != nil {
+		attr.Script = resp.Attrs.Script
+	}
+	return nil
 }
 
 func launchableBuildModeName(info *store.LaunchableResponse) string {

--- a/pkg/cmd/gpucreate/gpucreate_test.go
+++ b/pkg/cmd/gpucreate/gpucreate_test.go
@@ -110,6 +110,12 @@ func (m *MockGPUCreateStore) GetLaunchable(launchableID string) (*store.Launchab
 	}, nil
 }
 
+func (m *MockGPUCreateStore) GetLaunchableLifeCycleScript(launchableID, scriptID string) (*store.LifeCycleScriptResponse, error) {
+	return &store.LifeCycleScriptResponse{
+		Attrs: &store.LifeCycleScriptAttr{ID: scriptID, Script: "echo mock-script"},
+	}, nil
+}
+
 func (m *MockGPUCreateStore) RedeemCouponCode(organizationID string, code string) (*store.RedeemCouponCodeResponse, error) {
 	return &store.RedeemCouponCodeResponse{}, nil
 }

--- a/pkg/cmd/gpucreate/gpucreate_test.go
+++ b/pkg/cmd/gpucreate/gpucreate_test.go
@@ -14,14 +14,15 @@ import (
 
 // MockGPUCreateStore is a mock implementation of GPUCreateStore for testing
 type MockGPUCreateStore struct {
-	User                *entity.User
-	Org                 *entity.Organization
-	Workspaces          map[string]*entity.Workspace
-	CreateError         error
-	CreateErrorTypes    map[string]error // Errors for specific instance types
-	DeleteError         error
-	CreatedWorkspaces   []*entity.Workspace
-	DeletedWorkspaceIDs []string
+	User                      *entity.User
+	Org                       *entity.Organization
+	Workspaces                map[string]*entity.Workspace
+	CreateError               error
+	CreateErrorTypes          map[string]error // Errors for specific instance types
+	DeleteError               error
+	CreatedWorkspaces         []*entity.Workspace
+	DeletedWorkspaceIDs       []string
+	FetchedLifeCycleScriptIDs []string
 }
 
 func NewMockGPUCreateStore() *MockGPUCreateStore {
@@ -111,6 +112,7 @@ func (m *MockGPUCreateStore) GetLaunchable(launchableID string) (*store.Launchab
 }
 
 func (m *MockGPUCreateStore) GetLaunchableLifeCycleScript(launchableID, scriptID string) (*store.LifeCycleScriptResponse, error) {
+	m.FetchedLifeCycleScriptIDs = append(m.FetchedLifeCycleScriptIDs, scriptID)
 	return &store.LifeCycleScriptResponse{
 		Attrs: &store.LifeCycleScriptAttr{ID: scriptID, Script: "echo mock-script"},
 	}, nil
@@ -670,4 +672,78 @@ func TestPollUntilReadyReportsWorkspaceFailureMessage(t *testing.T) {
 	err := ctx.pollUntilReady("ws-failed")
 
 	assert.ErrorContains(t, err, "instance test failed: unexpected end of JSON input")
+}
+
+func TestInlineLaunchableLifeCycleScript(t *testing.T) {
+	t.Run("fetches and inlines lifecycle script body", func(t *testing.T) {
+		mockStore := NewMockGPUCreateStore()
+		info := &store.LaunchableResponse{
+			BuildRequest: store.LaunchableBuildRequest{
+				VMBuild: &store.VMBuild{
+					LifeCycleScriptAttr: &store.LifeCycleScriptAttr{ID: "ls-abc"},
+				},
+			},
+		}
+
+		err := inlineLaunchableLifeCycleScript(mockStore, "env-abc", info)
+
+		assert.NoError(t, err)
+		assert.Equal(t, []string{"ls-abc"}, mockStore.FetchedLifeCycleScriptIDs)
+		assert.Equal(t, "echo mock-script", info.BuildRequest.VMBuild.LifeCycleScriptAttr.Script)
+	})
+
+	t.Run("skips fetch when info is nil", func(t *testing.T) {
+		mockStore := NewMockGPUCreateStore()
+
+		err := inlineLaunchableLifeCycleScript(mockStore, "env-abc", nil)
+
+		assert.NoError(t, err)
+		assert.Empty(t, mockStore.FetchedLifeCycleScriptIDs)
+	})
+
+	t.Run("container build skips lifecycle script fetch", func(t *testing.T) {
+		mockStore := NewMockGPUCreateStore()
+		info := &store.LaunchableResponse{
+			BuildRequest: store.LaunchableBuildRequest{
+				CustomContainer: &store.CustomContainer{ContainerURL: "nvcr.io/nvidia/test:latest"},
+			},
+		}
+
+		err := inlineLaunchableLifeCycleScript(mockStore, "env-abc", info)
+
+		assert.NoError(t, err)
+		assert.Empty(t, mockStore.FetchedLifeCycleScriptIDs)
+	})
+
+	t.Run("skips fetch when launchable has no lifecycle script", func(t *testing.T) {
+		mockStore := NewMockGPUCreateStore()
+		info := &store.LaunchableResponse{
+			BuildRequest: store.LaunchableBuildRequest{
+				VMBuild: &store.VMBuild{ForceJupyterInstall: true},
+			},
+		}
+
+		err := inlineLaunchableLifeCycleScript(mockStore, "env-abc", info)
+
+		assert.NoError(t, err)
+		assert.Empty(t, mockStore.FetchedLifeCycleScriptIDs)
+		assert.Nil(t, info.BuildRequest.VMBuild.LifeCycleScriptAttr)
+	})
+
+	t.Run("skips fetch when script ID is empty", func(t *testing.T) {
+		mockStore := NewMockGPUCreateStore()
+		info := &store.LaunchableResponse{
+			BuildRequest: store.LaunchableBuildRequest{
+				VMBuild: &store.VMBuild{
+					LifeCycleScriptAttr: &store.LifeCycleScriptAttr{Name: "stale"},
+				},
+			},
+		}
+
+		err := inlineLaunchableLifeCycleScript(mockStore, "env-abc", info)
+
+		assert.NoError(t, err)
+		assert.Empty(t, mockStore.FetchedLifeCycleScriptIDs)
+		assert.Equal(t, "", info.BuildRequest.VMBuild.LifeCycleScriptAttr.Script)
+	})
 }

--- a/pkg/store/workspace.go
+++ b/pkg/store/workspace.go
@@ -283,6 +283,29 @@ func (s AuthHTTPStore) GetLaunchable(launchableID string) (*LaunchableResponse, 
 	return &result, nil
 }
 
+// LifeCycleScriptResponse holds a lifecycle script with the script body populated.
+type LifeCycleScriptResponse struct {
+	Attrs *LifeCycleScriptAttr `json:"attrs"`
+}
+
+// GetLaunchableLifeCycleScript fetches the full lifecycle script for a launchable.
+func (s AuthHTTPStore) GetLaunchableLifeCycleScript(launchableID, scriptID string) (*LifeCycleScriptResponse, error) {
+	var result LifeCycleScriptResponse
+	res, err := s.authHTTPClient.restyClient.R().
+		SetHeader("Content-Type", "application/json").
+		SetQueryParam("envId", launchableID).
+		SetQueryParam("scriptId", scriptID).
+		SetResult(&result).
+		Get("api/launchable/lifecycle-script")
+	if err != nil {
+		return nil, breverrors.WrapAndTrace(err)
+	}
+	if res.IsError() {
+		return nil, NewHTTPResponseError(res)
+	}
+	return &result, nil
+}
+
 type GetWorkspacesOptions struct {
 	UserID string
 	Name   string


### PR DESCRIPTION
## Summary

  - `brev create <name> --launchable <id>` failed with `rpc error: code = Internal desc = lifecycle script is empty` whenever the launchable had a lifecycle script attached.
  - The launchable GET endpoint returns `lifeCycleScriptAttr` as an `{id, name}` reference; the script body is stored in blobstore and is not inlined, passed on user's request but not returned on get or list. The backend's create-workspace path requires the client to supply the script content.
  - The Brev Console handles this by calling `GET /api/launchable/lifecycle-script?envId=...&scriptId=...` and inlining the response into `attrs.script` before sending create request. The CLI did not, it forwarded the reference as-is.

  This PR makes the CLI mirror the Brev Console:

  1. New store method `AuthHTTPStore.GetLaunchableLifeCycleScript` hitting the same endpoint the Console uses.
  2. `fetchAndDisplayLaunchable` now calls `inlineLaunchableLifeCycleScript`, which fetches and inlines the body when `attr.ID` is set and `attr.Script` is empty.
  3. Brev client gate the fetch on `id` presence, so launchables with no lifecycle script remain unaffected — the field stays `nil`, `omitempty` drops it from the POST, and the backend's `hasLifecycleScript` returns false (no validation).