### PR TITLE
fix: ignore nix dev files

### DIFF
--- a/.direnv/flake-profile
+++ b/.direnv/flake-profile
@@ -1,1 +1,0 @@
-flake-profile-13-link

--- a/.direnv/flake-profile-1-link
+++ b/.direnv/flake-profile-1-link
@@ -1,1 +1,0 @@
-/nix/store/8n92g7fw4nix506iwq8nl1fb6ay2sdgc-nix-shell-env

--- a/.direnv/flake-profile-10-link
+++ b/.direnv/flake-profile-10-link
@@ -1,1 +1,0 @@
-/nix/store/bz0fxgpxhnhd5k6pl94yx5b0cnkihjfm-nix-shell-env

--- a/.direnv/flake-profile-11-link
+++ b/.direnv/flake-profile-11-link
@@ -1,1 +1,0 @@
-/nix/store/vlm7h8szz6zk7pw4kbf6rx6wgzz2xkwp-nix-shell-env

--- a/.direnv/flake-profile-12-link
+++ b/.direnv/flake-profile-12-link
@@ -1,1 +1,0 @@
-/nix/store/mnyy3zgc5kaij16qzkfkh7b228y6drg1-nix-shell-env

--- a/.direnv/flake-profile-13-link
+++ b/.direnv/flake-profile-13-link
@@ -1,1 +1,0 @@
-/nix/store/kx2kx5d0fbjdrcmpw8aq3ldv8c1rr3v0-nix-shell-env

--- a/.direnv/flake-profile-2-link
+++ b/.direnv/flake-profile-2-link
@@ -1,1 +1,0 @@
-/nix/store/q19smb3y056p32ziwy4kx7rxmma0m1v0-nix-shell-env

--- a/.direnv/flake-profile-3-link
+++ b/.direnv/flake-profile-3-link
@@ -1,1 +1,0 @@
-/nix/store/3z0dhrbjl6ixk8rnflizdxjsqp363dg4-nix-shell-env

--- a/.direnv/flake-profile-4-link
+++ b/.direnv/flake-profile-4-link
@@ -1,1 +1,0 @@
-/nix/store/9virk8id889lkdr93d5sv03wywybxcrq-nix-shell-env

--- a/.direnv/flake-profile-5-link
+++ b/.direnv/flake-profile-5-link
@@ -1,1 +1,0 @@
-/nix/store/lzbfvrsqj2q22h2b99dcicbhcxcy9bqy-nix-shell-env

--- a/.direnv/flake-profile-6-link
+++ b/.direnv/flake-profile-6-link
@@ -1,1 +1,0 @@
-/nix/store/m12racr5hxc041wzs28iivg142fb91qf-nix-shell-env

--- a/.direnv/flake-profile-7-link
+++ b/.direnv/flake-profile-7-link
@@ -1,1 +1,0 @@
-/nix/store/6znavhsxp7n9x5a6fmjy3mnzjwbpzsw0-nix-shell-env

--- a/.direnv/flake-profile-8-link
+++ b/.direnv/flake-profile-8-link
@@ -1,1 +1,0 @@
-/nix/store/mzhw4r4fwncli7rz89h5lfa6fnx2dnlx-nix-shell-env

--- a/.direnv/flake-profile-9-link
+++ b/.direnv/flake-profile-9-link
@@ -1,1 +1,0 @@
-/nix/store/smfaqmssbm1y8qi1iwb6s4a70247j3qg-nix-shell-env

--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,8 @@ test.txt
 test2.txt
 homebrew-brev
 flake-explorations
+
+# nix caches/outputs
+result
+result-*
+.direnv

--- a/flake-explorations/result
+++ b/flake-explorations/result
@@ -1,1 +1,0 @@
-/nix/store/gl5a41azbpsadfkfmbilh9yk40dh5dl0-hello-2.12.1


### PR DESCRIPTION
removes and ignores nix dev files

```
 file .direnv/*
.direnv/flake-profile:         broken symbolic link to flake-profile-13-link
.direnv/flake-profile-10-link: broken symbolic link to /nix/store/bz0fxgpxhnhd5k6pl94yx5b0cnkihjfm-nix-shell-env
.direnv/flake-profile-11-link: broken symbolic link to /nix/store/vlm7h8szz6zk7pw4kbf6rx6wgzz2xkwp-nix-shell-env
.direnv/flake-profile-12-link: broken symbolic link to /nix/store/mnyy3zgc5kaij16qzkfkh7b228y6drg1-nix-shell-env
.direnv/flake-profile-13-link: broken symbolic link to /nix/store/kx2kx5d0fbjdrcmpw8aq3ldv8c1rr3v0-nix-shell-env
.direnv/flake-profile-1-link:  broken symbolic link to /nix/store/8n92g7fw4nix506iwq8nl1fb6ay2sdgc-nix-shell-env
.direnv/flake-profile-2-link:  broken symbolic link to /nix/store/q19smb3y056p32ziwy4kx7rxmma0m1v0-nix-shell-env
.direnv/flake-profile-3-link:  broken symbolic link to /nix/store/3z0dhrbjl6ixk8rnflizdxjsqp363dg4-nix-shell-env
.direnv/flake-profile-4-link:  broken symbolic link to /nix/store/9virk8id889lkdr93d5sv03wywybxcrq-nix-shell-env
.direnv/flake-profile-5-link:  broken symbolic link to /nix/store/lzbfvrsqj2q22h2b99dcicbhcxcy9bqy-nix-shell-env
.direnv/flake-profile-6-link:  broken symbolic link to /nix/store/m12racr5hxc041wzs28iivg142fb91qf-nix-shell-env
.direnv/flake-profile-7-link:  broken symbolic link to /nix/store/6znavhsxp7n9x5a6fmjy3mnzjwbpzsw0-nix-shell-env
.direnv/flake-profile-8-link:  broken symbolic link to /nix/store/mzhw4r4fwncli7rz89h5lfa6fnx2dnlx-nix-shell-env
.direnv/flake-profile-9-link:  broken symbolic link to /nix/store/smfaqmssbm1y8qi1iwb6s4a70247j3qg-nix-shell-env
```