### PR TITLE
fix: trigger duplicate interactive login prompts when logged out

### DIFF
--- a/pkg/cmd/copy/copy.go
+++ b/pkg/cmd/copy/copy.go
@@ -37,6 +37,7 @@ type CopyStore interface {
 	StartWorkspace(workspaceID string) (*entity.Workspace, error)
 	GetWorkspace(workspaceID string) (*entity.Workspace, error)
 	GetCurrentUserKeys() (*entity.UserKeys, error)
+	GetAccessToken() (string, error)
 }
 
 func NewCmdCopy(t *terminal.Terminal, store CopyStore, noLoginStartStore CopyStore) *cobra.Command {
@@ -65,6 +66,9 @@ func NewCmdCopy(t *terminal.Terminal, store CopyStore, noLoginStartStore CopySto
 }
 
 func runCopyCommand(t *terminal.Terminal, cstore CopyStore, source, dest string, host bool) error {
+	if _, err := cstore.GetAccessToken(); err != nil {
+		return breverrors.WrapAndTrace(err)
+	}
 	workspaceNameOrID, remotePath, localPath, isUpload, err := parseCopyArguments(source, dest)
 	if err != nil {
 		return breverrors.WrapAndTrace(err)

--- a/pkg/cmd/portforward/portforward.go
+++ b/pkg/cmd/portforward/portforward.go
@@ -31,6 +31,7 @@ type PortforwardStore interface {
 	refresh.RefreshStore
 	util.GetWorkspaceByNameOrIDErrStore
 	util.MakeWorkspaceWithMetaStore
+	GetAccessToken() (string, error)
 }
 
 func NewCmdPortForwardSSH(pfStore PortforwardStore, t *terminal.Terminal) *cobra.Command {
@@ -87,6 +88,9 @@ func isPortAlreadyAllocatedError(err error) bool {
 }
 
 func RunPortforward(t *terminal.Terminal, pfStore PortforwardStore, nameOrID string, portString string, useHost bool) error {
+	if _, err := pfStore.GetAccessToken(); err != nil {
+		return breverrors.WrapAndTrace(err)
+	}
 	localPort, remotePort, err := parsePortString(portString)
 	if err != nil {
 		return err

--- a/pkg/cmd/shell/shell.go
+++ b/pkg/cmd/shell/shell.go
@@ -49,6 +49,7 @@ type ShellStore interface {
 	refresh.RefreshStore
 	GetOrganizations(options *store.GetOrganizationsOptions) ([]entity.Organization, error)
 	GetWorkspaces(organizationID string, options *store.GetWorkspacesOptions) ([]entity.Workspace, error)
+	GetAccessToken() (string, error)
 }
 
 func NewCmdShell(t *terminal.Terminal, store ShellStore, noLoginStartStore ShellStore) *cobra.Command {
@@ -80,6 +81,9 @@ func NewCmdShell(t *terminal.Terminal, store ShellStore, noLoginStartStore Shell
 const pollTimeout = 10 * time.Minute
 
 func runShellCommand(t *terminal.Terminal, sstore ShellStore, workspaceNameOrID string, host bool) error {
+	if _, err := sstore.GetAccessToken(); err != nil {
+		return breverrors.WrapAndTrace(err)
+	}
 	s := t.NewSpinner()
 	target, err := util.ResolveWorkspaceOrNode(sstore, workspaceNameOrID)
 	if err != nil {


### PR DESCRIPTION
Problem : `brev copy`, `brev shell`, and `brev port-forward`triggered multiple interactive login prompts when the access token was missing or expired. Parallel auth requests from command initialization and workspace resolution competed for stdin, causing login failures with a “declined to login” error.

Fix: Acquire the access token once, synchronously, at the start of each command before launching any concurrent work. If the user is logged out, the interactive login runs a single time; subsequent command flows share the same cached token.