### PR TITLE
fix: remove brev reset suggestion from brev ls output

### DIFF
--- a/pkg/cmd/ls/ls.go
+++ b/pkg/cmd/ls/ls.go
@@ -415,8 +415,6 @@ func (ls Ls) ShowOrgWorkspaces(org *entity.Organization, workspaces []entity.Wor
 	displayWorkspacesTable(ls.terminal, workspaces, gpuLookup)
 
 	fmt.Print("\n")
-
-	displayLsResetBreadCrumb(ls.terminal, workspaces)
 }
 
 func (ls Ls) displayWorkspacesAndHelp(org *entity.Organization, otherOrgs []entity.Organization, userWorkspaces []entity.Workspace, allWorkspaces []entity.Workspace, gpuLookup map[string]string) {
@@ -438,22 +436,6 @@ func (ls Ls) displayWorkspacesAndHelp(org *entity.Organization, otherOrgs []enti
 		displayWorkspacesTable(ls.terminal, userWorkspaces, gpuLookup)
 
 		fmt.Print("\n")
-
-		displayLsResetBreadCrumb(ls.terminal, userWorkspaces)
-		// displayLsConnectBreadCrumb(ls.terminal, userWorkspaces)
-	}
-}
-
-func displayLsResetBreadCrumb(t *terminal.Terminal, workspaces []entity.Workspace) {
-	foundAResettableWorkspace := false
-	for _, w := range workspaces {
-		if w.Status == entity.Failure || getWorkspaceDisplayStatus(w) == entity.Unhealthy {
-			if !foundAResettableWorkspace {
-				t.Vprintf("%s", t.Red("Reset unhealthy or failed instance:\n"))
-			}
-			t.Vprintf("%s", t.Yellow(fmt.Sprintf("\tbrev reset %s\n", w.Name)))
-			foundAResettableWorkspace = true
-		}
 	}
 }
 


### PR DESCRIPTION
## Summary
Removes the `Reset unhealthy or failed instance: brev reset <name>` suggestion shown in `brev ls` output for unhealthy/failed instances.

`brev reset` is only implemented for AWS in the backend for every other provider (GCP, Crusoe, Nebius, Shadeform, SFCompute, Launchpad) it returns "not implemented". Surfacing this suggestion to users on those providers was misleading and led them to a command that would fail.

Linear: [BREV-9452](https://linear.app/nvidia/issue/BREV-9452/brev-reset-command-is-not-supported-for-providers-except-aws)

## Changes
- Removed `displayLsResetBreadCrumb` function (now dead code)
- Removed call sites in `ShowOrgWorkspaces` and `displayWorkspacesAndHelp`