### PR TITLE
fix: friendly error when registering a node with a duplicate name

### DIFF
--- a/pkg/cmd/register/register.go
+++ b/pkg/cmd/register/register.go
@@ -3,6 +3,7 @@ package register
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os/user"
 	"strings"
@@ -292,13 +293,11 @@ func runRegisterSteps(ctx context.Context, t *terminal.Terminal, s RegisterStore
 		NodeSpec:       toProtoNodeSpec(hwProfile),
 	}))
 	if err != nil {
-		// Newer dev-plane returns CodeAlreadyExists for a duplicate node name.
-		// Older dev-plane leaks the raw Postgres unique-constraint error, so we
-		// also match the constraint name for backwards compatibility until the
-		// server change is fully rolled out.
-		if connect.CodeOf(err) == connect.CodeAlreadyExists ||
-			strings.Contains(err.Error(), "externalnode_organization_id_name") {
-			return nil, fmt.Errorf("a node with this name already exists")
+		// dev-plane returns CodeAlreadyExists for a duplicate node name; surface
+		// its message directly, which already reads as "node already exists".
+		var connectErr *connect.Error
+		if errors.As(err, &connectErr) && connectErr.Code() == connect.CodeAlreadyExists {
+			return nil, errors.New(connectErr.Message())
 		}
 		return nil, fmt.Errorf("failed to register node: %w", err)
 	}

--- a/pkg/cmd/register/register.go
+++ b/pkg/cmd/register/register.go
@@ -292,6 +292,12 @@ func runRegisterSteps(ctx context.Context, t *terminal.Terminal, s RegisterStore
 		NodeSpec:       toProtoNodeSpec(hwProfile),
 	}))
 	if err != nil {
+		// TODO: dev-plane should return a connect.CodeAlreadyExists error for a
+		// duplicate node name so we can match on the code instead of this brittle
+		// string match, which breaks if the constraint is ever renamed.
+		if strings.Contains(err.Error(), "externalnode_organization_id_name") {
+			return nil, fmt.Errorf("a node with this name already exists")
+		}
 		return nil, fmt.Errorf("failed to register node: %w", err)
 	}
 

--- a/pkg/cmd/register/register.go
+++ b/pkg/cmd/register/register.go
@@ -292,10 +292,12 @@ func runRegisterSteps(ctx context.Context, t *terminal.Terminal, s RegisterStore
 		NodeSpec:       toProtoNodeSpec(hwProfile),
 	}))
 	if err != nil {
-		// TODO: dev-plane should return a connect.CodeAlreadyExists error for a
-		// duplicate node name so we can match on the code instead of this brittle
-		// string match, which breaks if the constraint is ever renamed.
-		if strings.Contains(err.Error(), "externalnode_organization_id_name") {
+		// Newer dev-plane returns CodeAlreadyExists for a duplicate node name.
+		// Older dev-plane leaks the raw Postgres unique-constraint error, so we
+		// also match the constraint name for backwards compatibility until the
+		// server change is fully rolled out.
+		if connect.CodeOf(err) == connect.CodeAlreadyExists ||
+			strings.Contains(err.Error(), "externalnode_organization_id_name") {
 			return nil, fmt.Errorf("a node with this name already exists")
 		}
 		return nil, fmt.Errorf("failed to register node: %w", err)


### PR DESCRIPTION
## What

When `brev register` hits a duplicate node name, the user currently sees the raw Postgres error from dev-plane:

```
[Step 3/5] Registering device with Brev...
failed to register node: internal: pq: duplicate key value violates unique constraint "externalnode_organization_id_name"
```

This intercepts that case on the `AddNode` RPC and surfaces a clean message instead:

```
a node with this name already exists
```

Any other registration error still falls through to the existing `failed to register node: %w` path.

## How

The match is forward-compatible across the dev-plane rollout:

- **New dev-plane** returns `connect.CodeAlreadyExists` → matched via `connect.CodeOf(err)`.
- **Old dev-plane** leaks the raw `pq` unique-constraint error → matched via the `externalnode_organization_id_name` constraint-name string.

The string match can be removed once the dev-plane change is fully deployed.

## Companion PR

brevdev/dev-plane#2277 — makes `AddNode` return `connect.CodeAlreadyExists` instead of leaking the Postgres constraint error.

