### PR TITLE
fix: validate instance is stoppable before stop

### DIFF
--- a/pkg/cmd/stop/stop.go
+++ b/pkg/cmd/stop/stop.go
@@ -105,6 +105,12 @@ func stopAllWorkspaces(t *terminal.Terminal, stopStore StopStore, piped bool) er
 	var stoppedNames []string
 	for _, v := range workspaces {
 		if v.Status == entity.Running {
+			if err := validateWorkspaceStoppable(&v); err != nil {
+				if !piped {
+					t.Vprintf("%s", t.Yellow("\n%s skipped (does not support stop)", v.Name))
+				}
+				continue
+			}
 			_, err = stopStore.StopWorkspace(v.ID)
 			if err != nil {
 				return breverrors.WrapAndTrace(err)
@@ -168,6 +174,9 @@ func stopWorkspace(workspaceName string, t *terminal.Terminal, stopStore StopSto
 				}
 			}
 		}
+		if err = validateWorkspaceStoppable(workspace); err != nil {
+			return err
+		}
 		workspaceID = workspace.ID
 	}
 
@@ -185,4 +194,13 @@ func stopWorkspace(workspaceName string, t *terminal.Terminal, stopStore StopSto
 	}
 
 	return nil
+}
+
+func validateWorkspaceStoppable(workspace *entity.Workspace) error {
+	if workspace.InstanceTypeInfo != nil && workspace.InstanceTypeInfo.Stoppable {
+		return nil
+	}
+	return breverrors.NewValidationError(fmt.Sprintf(
+		"instance %q does not support stop.",
+		workspace.Name))
 }

--- a/pkg/entity/entity.go
+++ b/pkg/entity/entity.go
@@ -279,7 +279,7 @@ type WorkspaceGroup struct {
 	TenantType     string `json:"tenantType"`
 } // @Name WorkspaceGroup
 
-type WorkspaceInstanceTypeInfo struct {
+type InstanceTypeInfo struct {
 	Stoppable bool `json:"stoppable"`
 }
 
@@ -291,7 +291,7 @@ type Workspace struct {
 	WorkspaceClassID     string            `json:"workspaceClassId"` // WorkspaceClassID is resources, like "2x8"
 	InstanceType         string            `json:"instanceType,omitempty"`
 	CreatedByUserID      string            `json:"createdByUserId"`
-	InstanceTypeInfo     *WorkspaceInstanceTypeInfo `json:"instanceTypeInfo,omitempty"`
+	InstanceTypeInfo     *InstanceTypeInfo `json:"instanceTypeInfo,omitempty"`
 	DNS                  string            `json:"dns"`
 	Status               string            `json:"status"`
 	Password             string            `json:"password"`

--- a/pkg/entity/entity.go
+++ b/pkg/entity/entity.go
@@ -279,6 +279,10 @@ type WorkspaceGroup struct {
 	TenantType     string `json:"tenantType"`
 } // @Name WorkspaceGroup
 
+type WorkspaceInstanceTypeInfo struct {
+	Stoppable bool `json:"stoppable"`
+}
+
 type Workspace struct {
 	ID                   string            `json:"id"`
 	Name                 string            `json:"name"`
@@ -287,6 +291,7 @@ type Workspace struct {
 	WorkspaceClassID     string            `json:"workspaceClassId"` // WorkspaceClassID is resources, like "2x8"
 	InstanceType         string            `json:"instanceType,omitempty"`
 	CreatedByUserID      string            `json:"createdByUserId"`
+	InstanceTypeInfo     *WorkspaceInstanceTypeInfo `json:"instanceTypeInfo,omitempty"`
 	DNS                  string            `json:"dns"`
 	Status               string            `json:"status"`
 	Password             string            `json:"password"`


### PR DESCRIPTION
**Issue:**
brev stop <instance> and brev stop --all call the stop workflow without checking whether the instance type supports stop/start.

**Fix:**
- Check instanceTypeInfo.stoppable before stopping named instances
- Skip non-stoppable running instances in brev stop --all with a warning