### PR TITLE
fix(auth): gracefully re-prompt on empty email during login

### DIFF
--- a/pkg/auth/kas.go
+++ b/pkg/auth/kas.go
@@ -159,14 +159,14 @@ func (a KasAuthenticator) maybePromptForEmail() (string, error) {
 	} else if a.Email != "" {
 		return a.Email, nil
 	} else {
-		t := terminal.New()
-		fmt.Print(t.Green("Enter your email: "))
-		_, err := fmt.Scanln(&email)
-		if err != nil {
-			return "", breverrors.WrapAndTrace(err)
-		}
+		// PromptGetInput validates and re-prompts on empty input, so hitting
+		// enter with no email no longer surfaces a raw "unexpected newline" error.
+		email = terminal.PromptGetInput(terminal.PromptContent{
+			Label:    "Enter your email:",
+			ErrorMsg: "please enter a valid email address",
+		})
 	}
-	return email, nil
+	return strings.TrimSpace(email), nil
 }
 
 func (a KasAuthenticator) pollForTokens(sessionKey, id string) (*LoginTokens, error) {


### PR DESCRIPTION
## Problem

Running `brev register` (or any login flow) and hitting **enter** with no input at the `Enter your email:` prompt produced a confusing error and a raw RESTY stack trace:

```
Enter your email:
failed.

2026/07/01 23:32:03 WARN RESTY [error] ...maybePromptForEmail... : unexpected newline
```

`fmt.Scanln` treats an empty line as an `"unexpected newline"` error, which was wrapped and propagated all the way up through the auth stack.

## Fix

Replace the raw `fmt.Scanln` call in `KasAuthenticator.maybePromptForEmail` with the existing `terminal.PromptGetInput` helper (built on `promptui`, already used across ~10 commands). It validates input and **re-prompts automatically** on empty input, so entering a blank email now shows a friendly message instead of crashing.

## Notes

- The other branch of `maybePromptForEmail` (the "press enter to continue" confirmation) still uses `fmt.Scanln`, but it already tolerates the `"unexpected newline"` case, so it is unaffected by this bug and left unchanged to keep the diff focused.