### PR TITLE
fix(auth): always show login URL so headless login can complete

### DIFF
--- a/pkg/auth/auth.go
+++ b/pkg/auth/auth.go
@@ -4,9 +4,8 @@ import (
 	"bufio"
 	"errors"
 	"fmt"
+	"io"
 	"os"
-	"os/exec"
-	"runtime"
 	"strings"
 
 	"github.com/brevdev/brev-cli/pkg/config"
@@ -324,10 +323,20 @@ func (t Auth) LoginWithAPIKey(apiKey string, orgID string) error {
 	return nil
 }
 
-// showLoginURL displays the login link and CLI alternative for manual navigation.
+func init() {
+	// pkg/browser pipes the launcher's stderr to ours, which leaks confusing
+	// noise like "xdg-open: no DISPLAY environment variable specified" on
+	// headless machines. We always print the login URL, so discard it.
+	browser.Stderr = io.Discard
+}
+
+// showLoginURL prints the login link, framed as a fallback for when the
+// browser doesn't open (e.g. headless machine, wrong default browser).
 func showLoginURL(url string) {
 	urlType := color.New(color.FgCyan, color.Bold).SprintFunc()
-	fmt.Println("Login here: " + urlType(url))
+	fmt.Println("Browser didn't open? Use the URL below to sign in:")
+	fmt.Println()
+	fmt.Println(urlType(url))
 }
 
 func defaultAuthFunc(url, code string) {
@@ -337,12 +346,9 @@ func defaultAuthFunc(url, code string) {
 		fmt.Print("\n")
 	}
 
-	if hasBrowser() {
-		if err := browser.OpenURL(url); err == nil {
-			fmt.Println("Waiting for login to complete in browser...")
-			return
-		}
-	}
+	// Best-effort: try to open the browser, but always show the URL below so
+	// the user is never stranded if it doesn't open.
+	_ = browser.OpenURL(url)
 	showLoginURL(url)
 	fmt.Println("\nWaiting for login to complete...")
 }
@@ -350,21 +356,6 @@ func defaultAuthFunc(url, code string) {
 func skipBrowserAuthFunc(url, _ string) {
 	showLoginURL(url)
 	fmt.Println("\nWaiting for login to complete...")
-}
-
-// hasBrowser reports whether a browser can be opened on the current platform.
-func hasBrowser() bool {
-	if runtime.GOOS == "darwin" {
-		// macOS always has "open".
-		return true
-	}
-	// Linux: check for a known browser launcher.
-	for _, name := range []string{"xdg-open", "x-www-browser", "www-browser"} {
-		if _, err := exec.LookPath(name); err == nil {
-			return true
-		}
-	}
-	return false
 }
 
 func (t Auth) Login(skipBrowser bool) (*LoginTokens, error) {


### PR DESCRIPTION
## Problem

`brev register` (and any login flow) hangs and times out after 5 minutes on a headless machine (e.g. an SSH'd server):

```
Enter your email: alecf@nvidia.com
Waiting for login to complete in browser...
Error: no DISPLAY environment variable specified
failed.
...
timed out waiting for login
```

### Root cause

On a machine with no display but `xdg-open` installed:

1. `hasBrowser()` returned `true` — it only checked whether `xdg-open` existed, not whether a display was available.
2. `defaultAuthFunc` called `browser.OpenURL(url)`. `xdg-open` printed `Error: no DISPLAY environment variable specified` to stderr but **exited 0**, so `OpenURL` returned `nil`.
3. The code took the success branch: printed *"Waiting for login to complete in browser..."* and returned — **without ever printing the login URL**.
4. With no URL to visit, login could never complete, so polling ran its full 5-minute timeout and failed.

## Fix

Follow the same pattern Claude Code's CLI uses: **always** attempt to open the browser best-effort, but **always** print the login URL as a fallback, so the user is never stranded regardless of environment.

- `defaultAuthFunc`: attempt `browser.OpenURL` (ignore the result), then always `showLoginURL`.
- `showLoginURL`: reframed as a fallback — `Browser didn't open? Use the URL below to sign in:`.
- Discard the launcher's stderr (`browser.Stderr = io.Discard`) — `pkg/browser` pipes it to ours, which is what leaked the confusing `no DISPLAY` message.
- This removes the need for any platform/display detection, so `hasBrowser()` is deleted (net −9 lines).

Note: `brev register` uses an in-memory device-login flow (it does not reuse `~/.brev` credentials), so it always hits this path — this fix is what unblocks `register` on headless machines.

## Testing

- `go build ./...`, `go vet ./pkg/auth/`, `go test ./pkg/auth/`
- Cross-built `linux/arm64` and ran on a headless (no `DISPLAY`) arm64 box: login now prints the URL instead of hanging.