### PR TITLE
fix(auth): remove Kubernetes service account token fallback

### DIFF
--- a/pkg/store/authtoken.go
+++ b/pkg/store/authtoken.go
@@ -2,7 +2,6 @@ package store
 
 import (
 	"fmt"
-	"io/ioutil"
 	"path"
 
 	"github.com/brevdev/brev-cli/pkg/entity"
@@ -49,13 +48,6 @@ tokens, err := authtokens.ReadAuthTokensFromDisk()
 */
 
 func (f FileStore) GetAuthTokens() (*entity.AuthTokens, error) {
-	serviceToken, err := f.GetCurrentWorkspaceServiceToken()
-	if err == nil && serviceToken != "" {
-		return &entity.AuthTokens{
-			AccessToken: serviceToken,
-		}, nil
-	}
-
 	brevCredentialsFile, err := f.getBrevCredentialsFile()
 	if err != nil {
 		return nil, breverrors.WrapAndTrace(err)
@@ -75,32 +67,6 @@ func (f FileStore) GetAuthTokens() (*entity.AuthTokens, error) {
 		return nil, breverrors.WrapAndTrace(err)
 	}
 	return &token, nil
-}
-
-func (f FileStore) GetCurrentWorkspaceServiceToken() (string, error) {
-	saTokenFilePath := getServiceTokenFilePath()
-	// safely check if file exists
-
-	exists, err := f.FileExists(saTokenFilePath)
-
-	if !exists || err != nil {
-		return "", err
-	}
-
-	saTokenFile, err := f.fs.Open(saTokenFilePath)
-	defer saTokenFile.Close() //nolint: errcheck // defer is fine
-	if err != nil {
-		return "", breverrors.WrapAndTrace(err)
-	}
-	token, err := ioutil.ReadAll(saTokenFile)
-	if err != nil {
-		return "", breverrors.WrapAndTrace(err)
-	}
-	return string(token), nil
-}
-
-func getServiceTokenFilePath() string {
-	return "/var/run/secrets/kubernetes.io/serviceaccount/token"
 }
 
 func (f FileStore) DeleteAuthTokens() error {


### PR DESCRIPTION
## Investigation Summary 
The authentication flow checked for a Kubernetes service-account token before reading $HOME/.brev/credentials.json.

## Fix 
- Removed the Kubernetes service-account token check from GetAuthTokens. 
- Removed the now-unused GetCurrentWorkspaceServiceToken and getServiceTokenFilePath functions. 
- Brev authentication now reads credentials only from $HOME/.brev/credentials.json. 

**Relevant Ticket:** https://linear.app/nvidia/issue/BREV-11127/brev-cli-incorrectly-prioritizes-kubernetes-serviceaccount-token-over
