### PR TITLE
fix: forward Launchable base image

### DIFF
--- a/pkg/cmd/gpucreate/gpucreate.go
+++ b/pkg/cmd/gpucreate/gpucreate.go
@@ -1374,6 +1374,9 @@ func applyLaunchableWorkspaceRequest(cwOptions *store.CreateWorkspacesOptions, w
 	if wsReq.SubLocation != "" {
 		cwOptions.SubLocation = wsReq.SubLocation
 	}
+	if wsReq.ImageID != "" {
+		cwOptions.BaseImage = wsReq.ImageID
+	}
 
 	// Disk storage — the API may return a bare number (e.g., "256") or with
 	// a unit suffix (e.g., "256Gi"). The server's ParseDiskStorage expects a

--- a/pkg/cmd/gpucreate/gpucreate_test.go
+++ b/pkg/cmd/gpucreate/gpucreate_test.go
@@ -309,6 +309,7 @@ func TestApplyLaunchableConfig(t *testing.T) { //nolint:funlen // test
 				Storage:      "256",
 				Location:     "us-west1",
 				SubLocation:  "us-west1-b",
+				ImageID:      "projects/example/global/images/custom-image",
 				FirewallRules: []store.CreateFirewallRule{
 					{Port: "8080", AllowedIPs: "all"},
 					{Port: "9000-9100", AllowedIPs: "all"},
@@ -340,6 +341,7 @@ func TestApplyLaunchableConfig(t *testing.T) { //nolint:funlen // test
 		// Location / sub-location
 		assert.Equal(t, "us-west1", cwOptions.Location)
 		assert.Equal(t, "us-west1-b", cwOptions.SubLocation)
+		assert.Equal(t, "projects/example/global/images/custom-image", cwOptions.BaseImage)
 		// Storage with Gi suffix
 		assert.Equal(t, "256Gi", cwOptions.DiskStorage)
 		// Build config
@@ -611,6 +613,7 @@ func TestLaunchableJSONWireFormat(t *testing.T) {
 			InstanceType: "n2-standard-4",
 			Location:     "us-west1",
 			SubLocation:  "us-west1-b",
+			ImageID:      "projects/example/global/images/custom-image",
 			FirewallRules: []store.CreateFirewallRule{
 				{Port: "8080", AllowedIPs: "all"},
 				{Port: "22", AllowedIPs: "user-ip", ClientIPs: []string{"203.0.113.7/32"}},
@@ -627,6 +630,7 @@ func TestLaunchableJSONWireFormat(t *testing.T) {
 	s := string(body)
 
 	assert.Contains(t, s, `"subLocation":"us-west1-b"`)
+	assert.Contains(t, s, `"baseImage":"projects/example/global/images/custom-image"`)
 	assert.Contains(t, s, `"firewallRules":`)
 	assert.Contains(t, s, `"port":"8080"`)
 	assert.Contains(t, s, `"port":"22"`)


### PR DESCRIPTION
## What

Forward `createWorkspaceRequest.imageId` from a Launchable response to the
workspace creation request as `baseImage`.

The regression coverage now checks both the populated
`CreateWorkspacesOptions.BaseImage` field and the serialized `baseImage` JSON
field.

## Why

`LaunchableWorkspaceRequest` already deserializes the API's `imageId`, but
`applyLaunchableWorkspaceRequest` did not copy it into
`CreateWorkspacesOptions.BaseImage`. As a result, `brev create --launchable`
silently dropped a Launchable's custom VM image and the workspace could boot
from the default image instead.

This surfaced in the NemoClaw staging E2E when the workspace created
successfully but did not contain the image-baked
`/etc/nemoclaw/provision.json` receipt:

- [Failed workflow run](https://github.com/NVIDIA/NemoClaw/actions/runs/30515290556)
- [Failed job](https://github.com/NVIDIA/NemoClaw/actions/runs/30515290556/job/90794043383)
- [Successful staging-image producer run](https://github.com/brevdev/nemoclaw-image/actions/runs/30518675986)

## Validation

- `gofmt -d pkg/cmd/gpucreate/gpucreate.go pkg/cmd/gpucreate/gpucreate_test.go`
- `go test ./pkg/cmd/gpucreate`

Both ran with Go 1.25.

## Manual follow-up after merge

This client fix is necessary but is not sufficient for the current NemoClaw
Launchable because its stored `createWorkspaceRequest` does not currently
contain an `imageId`.

1. Release a Brev CLI version containing this change.
2. In the Brev Console or Launchables API, create or update the standing
   NemoClaw staging Launchable so its `createWorkspaceRequest.imageId` is:

   ```text
   projects/brevdevprod/global/images/family/nemoclaw-brev-staging-cpu
   ```

3. Confirm through the Launchable configuration/API response that `imageId`
   is present. `brev create --dry-run` does not currently expose the selected
   image, so it is not sufficient for this check.
4. Create a disposable workspace using the new CLI release and Launchable.
   Verify:
   - `/etc/nemoclaw/provision.json` exists.
   - `/opt/nemoclaw-image/NemoClaw` exists.
   - The provision receipt identifies the expected image/source revision.
   - The workspace is deleted after validation.
5. Update the NemoClaw workflow's pinned Brev CLI version and SHA-256 checksum
   to the release containing this fix.
6. Manually update the NemoClaw repository variable
   `NEMOCLAW_STAGING_LAUNCHABLE_ID` only after the replacement Launchable has
   passed the probe above.
7. Dispatch the trusted full NemoClaw E2E and verify provisioning, checkout,
   test, and cleanup evidence.

This PR intentionally does not change `NEMOCLAW_STAGING_LAUNCHABLE_ID`.
