### PR TITLE
docs(skill): document `brev ls nodes` and the instance/node split

### DIFF
--- a/.agents/skills/brev-cli/SKILL.md
+++ b/.agents/skills/brev-cli/SKILL.md
@@ -27,7 +27,7 @@ Use this skill when users want to:
 - Port forward from remote to local
 - Manage organizations and instances
 
-**Trigger Keywords:** brev, gpu, cpu, instance, create instance, ssh, vram, vcpu, A100, H100, cloud gpu, cloud cpu, remote machine, shell, node, external node, brev ls nodes
+**Trigger Keywords:** brev, gpu, cpu, instance, create instance, ssh, vram, vcpu, A100, H100, cloud gpu, cloud cpu, remote machine, shell
 
 ## Quick Start
 

--- a/.agents/skills/brev-cli/SKILL.md
+++ b/.agents/skills/brev-cli/SKILL.md
@@ -27,7 +27,7 @@ Use this skill when users want to:
 - Port forward from remote to local
 - Manage organizations and instances
 
-**Trigger Keywords:** brev, gpu, cpu, instance, create instance, ssh, vram, vcpu, A100, H100, cloud gpu, cloud cpu, remote machine, shell
+**Trigger Keywords:** brev, gpu, cpu, instance, create instance, ssh, vram, vcpu, A100, H100, cloud gpu, cloud cpu, remote machine, shell, node, external node, brev ls nodes
 
 ## Quick Start
 
@@ -46,6 +46,9 @@ brev create my-instance --type g5.xlarge
 
 # List your instances
 brev ls
+
+# List external nodes (a separate list from `brev ls`)
+brev ls nodes
 
 # SSH into an instance (interactive)
 brev shell my-instance
@@ -169,6 +172,36 @@ brev copy my-instance:/remote/file ./local-path/
 brev port-forward my-instance -p 8080:8080
 ```
 
+### Listing Instances and Nodes
+`brev ls` covers two separate namespaces. External nodes never appear in
+`brev ls`, so check `brev ls nodes` before concluding a machine doesn't exist.
+
+```bash
+brev ls              # cloud instances
+brev ls instances    # same as above, explicit
+brev ls nodes        # external nodes only (machines registered to the org)
+brev ls orgs         # organizations
+brev ls --json       # machine-readable
+brev ls nodes --json
+```
+
+|  | `brev ls` | `brev ls nodes` |
+|---|---|---|
+| Status values | `RUNNING` / `STOPPED` | `Connected` / `Disconnected` |
+| Columns | NAME, STATUS, BUILD, SHELL, ID, MACHINE, GPU | NAME, STATUS |
+| `stop` / `start` / `delete` | yes | no — Brev doesn't manage their lifecycle |
+
+The two `--json` shapes differ: `brev ls nodes --json` is a top-level array,
+while `brev ls --json` wraps rows in `.workspaces`.
+
+```bash
+brev ls nodes --json | jq -r '.[].name'
+brev ls       --json | jq -r '.workspaces[].name'
+
+# Names of nodes that are currently connected
+brev ls nodes --json | jq -r '.[] | select(.status=="Connected") | .name'
+```
+
 ### Instance Management
 ```bash
 # List instances
@@ -267,6 +300,7 @@ Do this proactively when:
 
 **"Instance not found":**
 - Run `brev ls` to see available instances
+- Run `brev ls nodes` — external nodes are a separate list and never show up in `brev ls`
 - Check if you're in the correct org: `brev org ls`
 
 **"Failed to create instance":**

--- a/.agents/skills/brev-cli/reference/commands.md
+++ b/.agents/skills/brev-cli/reference/commands.md
@@ -211,8 +211,16 @@ brev search cpu | brev create my-cpu-box
 List instances in active org.
 
 ```bash
-brev ls [flags]
+brev ls [subcommand] [flags]
 ```
+
+**Subcommands:**
+| Subcommand | Lists |
+|---|---|
+| *(none)* | cloud instances |
+| `instances` | cloud instances (explicit form) |
+| `nodes` | external nodes only |
+| `orgs` | organizations |
 
 **Flags:**
 | Flag | Short | Description |
@@ -220,6 +228,37 @@ brev ls [flags]
 | `--org` | `-o` | Override active org |
 | `--all` | | Show all instances in org |
 | `--json` | | Output as JSON |
+
+#### Instances vs. external nodes
+
+Two separate namespaces — an external node never appears in `brev ls`.
+
+```bash
+$ brev ls
+ NAME         STATUS   BUILD      SHELL  ID         MACHINE         GPU
+ my-instance  RUNNING  COMPLETED  READY  jmorx0saw  n2d-standard-2  -
+
+$ brev ls nodes
+ NAME     STATUS
+ my-node  Connected
+```
+
+|  | `brev ls` | `brev ls nodes` |
+|---|---|---|
+| Status values | `RUNNING` / `STOPPED` | `Connected` / `Disconnected` |
+| Columns | NAME, STATUS, BUILD, SHELL, ID, MACHINE, GPU | NAME, STATUS |
+| `stop` / `start` / `delete` | yes | no |
+
+The two `--json` shapes differ — `brev ls nodes --json` returns a top-level
+array, `brev ls --json` wraps rows in `.workspaces`:
+
+```bash
+brev ls nodes --json | jq -r '.[].name'
+brev ls       --json | jq -r '.workspaces[].name'
+
+# Only the nodes that are currently connected
+brev ls nodes --json | jq -r '.[] | select(.status=="Connected") | .name'
+```
 
 When stdout is piped, outputs instance names only (one per line) for chaining.
 


### PR DESCRIPTION
## Problem

The `brev-cli` agent skill never mentioned `brev ls nodes`, so external nodes were effectively invisible to it. An agent that ran `brev ls`, saw no match, and concluded a machine didn't exist would be wrong on any org that registers external nodes — the two are separate namespaces and a node never appears in `brev ls`.

## What changed

Documentation only, no CLI behaviour changes.

**`.agents/skills/brev-cli/SKILL.md`**
- `brev ls nodes` in Quick Start
- New "Listing Instances and Nodes" section covering the `instances` / `nodes` / `orgs` subcommands, with a table contrasting the two namespaces (status vocabulary, columns, whether `stop`/`start`/`delete` apply)
- "Instance not found" troubleshooting now points at `brev ls nodes`

**`.agents/skills/brev-cli/reference/commands.md`**
- `brev ls` entry expanded with the subcommand table and side-by-side output samples

## The `--json` shape difference

Both files call out something that's easy to trip over when scripting: the two `--json` outputs have different shapes, so the same `jq` path can't serve both.

```bash
brev ls nodes --json | jq -r '.[].name'            # top-level array
brev ls       --json | jq -r '.workspaces[].name'  # rows wrapped in .workspaces
```

Using the wrong one fails with `Cannot index array with string "name"`.

## Verification

Every command shown was run against a live org on `v0.6.329`.
