### PR TITLE
fix(refresh): preserve host SSH route

### DIFF
--- a/pkg/cmd/refresh/sshaccess.go
+++ b/pkg/cmd/refresh/sshaccess.go
@@ -116,12 +116,6 @@ func resolveWorkspaceSSH(
 	workspace.SSHPort = int(port.GetPortNumber())
 	workspace.SSHUser = access.GetLinuxUser()
 	workspace.SSHProxyHostname = ""
-
-	// To support the "--host" fallback, preserve the legacy hostname information returned by the initial workspace query.
-	if providerHostname := providerSSHHostname(environment.GetInstance(), port.GetHostname()); providerHostname != "" {
-		workspace.HostSSHHostname = providerHostname
-		workspace.HostSSHProxyHostname = ""
-	}
 	return workspace, nil
 }
 
@@ -144,16 +138,4 @@ func findNetworkPort(networkInfo *devplanev1.EnvironmentNetworkInfo, portID stri
 		}
 	}
 	return nil
-}
-
-func providerSSHHostname(instance *devplanev1.Instance, workloadHostname string) string {
-	if instance == nil {
-		return ""
-	}
-	for _, hostname := range []string{instance.GetPublicIp(), instance.GetPublicDns(), instance.GetHostname()} {
-		if hostname != "" && hostname != workloadHostname {
-			return hostname
-		}
-	}
-	return ""
 }

--- a/pkg/cmd/refresh/sshaccess_test.go
+++ b/pkg/cmd/refresh/sshaccess_test.go
@@ -41,7 +41,7 @@ func (s *stubEnvironmentSSHClient) GetNetworkInfo(
 	}), nil
 }
 
-func TestEnrichWorkspacesWithSSHAccess_UsesCurrentUsersPort(t *testing.T) {
+func TestEnrichWorkspacesWithSSHAccess_UsesCurrentUsersPortWithoutChangingHostRoute(t *testing.T) {
 	workspace := entity.Workspace{
 		ID:                   "env-1",
 		Name:                 "container-env",
@@ -50,7 +50,8 @@ func TestEnrichWorkspacesWithSSHAccess_UsesCurrentUsersPort(t *testing.T) {
 		SSHUser:              "ubuntu",
 		SSHPort:              22,
 		HostSSHUser:          "ubuntu",
-		HostSSHPort:          22,
+		HostSSHPort:          41235,
+		HostSSHHostname:      "host-gateway.example.com",
 		SSHProxyHostname:     "legacy-proxy.example.com",
 		HostSSHProxyHostname: "legacy-host-proxy.example.com",
 	}
@@ -80,8 +81,6 @@ func TestEnrichWorkspacesWithSSHAccess_UsesCurrentUsersPort(t *testing.T) {
 	want.SSHPort = 41234
 	want.SSHUser = "root"
 	want.SSHProxyHostname = ""
-	want.HostSSHHostname = "203.0.113.10"
-	want.HostSSHProxyHostname = ""
 
 	if diff := cmp.Diff([]entity.Workspace{want}, got); diff != "" {
 		t.Fatalf("unexpected workspace (-want +got): %s", diff)


### PR DESCRIPTION
NemoClaw workflow blocker: [NVIDIA/NemoClaw#8924](https://github.com/NVIDIA/NemoClaw/issues/8924)

## Summary

- preserve the existing host SSH route when refresh enriches normal workspace SSH access
- remove provider-hostname replacement that combined a raw provider IP with the existing mapped host port
- require the refresh regression test to preserve the host hostname, port, user, and proxy configuration

## Problem

[PR #424](https://github.com/brevdev/brev-cli/pull/424) changed refresh to resolve normal workspace SSH through the SSH access and network APIs. That path also rewrote `HostSSHHostname` from the existing Brev gateway hostname to a provider public IP and cleared `HostSSHProxyHostname`.

The rewrite retained the existing `HostSSHPort`. For the reproduced GCP environments, that port is allocated on the Brev gateway, not on the raw provider IP. The resulting `<workspace>-host` target timed out before SSH authentication.

This blocks NVIDIA/NemoClaw's trusted `Exact staging Brev Launchable` job. The workflow requires `brev exec --host` to verify the exact boot image and baked runtime before it runs the full E2E suite. See [NVIDIA/NemoClaw#8924](https://github.com/NVIDIA/NemoClaw/issues/8924).

## Fix

`resolveWorkspaceSSH` now updates only the normal workspace SSH fields:

- `SSHHostname`
- `SSHPort`
- `SSHUser`
- `SSHProxyHostname`

It leaves the existing `HostSSH*` route from the workspace inventory unchanged. The regression test starts with a distinct host gateway, mapped port, user, and proxy. The test requires all host fields to remain unchanged after normal SSH enrichment.

## Live validation

The comparison used two existing environments created from separate Launchables that point to the same GCP image family. Both environments booted the expected concrete image.

| CLI refresh implementation | Generated `-host` target | Exact host probe | `brev exec --host` |
| --- | --- | --- | --- |
| `v0.6.330` | Brev gateway plus allocated port | Passed | Passed |
| `v0.6.334` | Provider public IP plus allocated port | Timed out | Timed out |
| This branch, built from `v0.6.334` source | Brev gateway plus allocated port | Passed on both environments | Passed |

The patched binary also read the expected GCE boot-image URI and NemoClaw provision receipt through `brev exec --host`.

No environment was created, stopped, or deleted during this validation. The installed CLI was not replaced.

## Validation

- `go run mvdan.cc/gofumpt -l -d -e ../pkg/cmd/refresh/sshaccess.go ../pkg/cmd/refresh/sshaccess_test.go`
- `go test -race ./pkg/cmd/refresh`
- `go test -race ./pkg/ssh -run '^(Test_makeSSHConfigEntryV2|TestCreateNewSSHConfig|TestCreateNewSSHConfig_WithNodes|TestCreateNewSSHConfig_WorkspacesAndNodes)$'`
- `go vet ./pkg/cmd/refresh`
- `golangci-lint run ./pkg/cmd/refresh`
- local current-source build and the live comparison above

The complete `pkg/ssh` test package has existing macOS environment failures: JetBrains Gateway path tests require a local installation, and `TestSSHConfigurerV2_Update` invokes a WSL-only fixture. The platform-independent SSH configuration tests listed above pass.

## Related work

- [#436](https://github.com/brevdev/brev-cli/issues/436) tracks selected-environment resolution and global refresh behavior for `brev exec --host`. This PR fixes the host endpoint corruption but does not close that broader issue.
