### PR TITLE
fix(exec): never replay remote commands after SSH failure

### DIFF
--- a/pkg/cmd/exec/exec.go
+++ b/pkg/cmd/exec/exec.go
@@ -191,6 +191,9 @@ func runExecCommand(t *terminal.Terminal, sstore ExecStore, workspaceNameOrID st
 		go trackExecAnalytics(sstore, workspaceNameOrID)
 		return nil
 	}
+	if !isSSHConnectionFailure(err) {
+		return breverrors.WrapAndTrace(err)
+	}
 
 	// SSH failed — now check what's going on with the instance
 	fmt.Fprintf(os.Stderr, "Connection failed, checking instance status...\n")
@@ -242,31 +245,14 @@ func runExecCommand(t *terminal.Terminal, sstore ExecStore, workspaceNameOrID st
 			workspaceNameOrID, workspace.Status))
 	}
 
-	// Instance is RUNNING but SSH failed — maybe still booting, do the wait
-	s := t.NewSpinner()
-	refreshRes := refresh.RunRefreshAsync(sstore)
-	if err = refreshRes.Await(); err != nil {
-		return breverrors.WrapAndTrace(err)
-	}
+	return breverrors.WrapAndTrace(fmt.Errorf(
+		"ssh connection to running instance %q failed; the remote command was not retried because it may already have executed: %w",
+		workspaceNameOrID, err))
+}
 
-	localIdentifier := workspace.GetLocalIdentifier()
-	if host {
-		localIdentifier = workspace.GetHostIdentifier()
-	}
-	sshName = string(localIdentifier)
-
-	err = util.WaitForSSHToBeAvailable(sshName, s)
-	if err != nil {
-		return breverrors.WrapAndTrace(fmt.Errorf(
-			"could not connect to instance %q: %w\nPlease check with: brev ls",
-			workspaceNameOrID, err))
-	}
-	err = runSSH(sshName, command)
-	if err != nil {
-		return breverrors.WrapAndTrace(err)
-	}
-	go trackExecAnalytics(sstore, workspaceNameOrID)
-	return nil
+func isSSHConnectionFailure(err error) bool {
+	var exitErr *exec.ExitError
+	return breverrors.As(err, &exitErr) && exitErr.ExitCode() == 255
 }
 
 func trackExecAnalytics(sstore ExecStore, workspaceNameOrID string) {

--- a/pkg/cmd/exec/exec_test.go
+++ b/pkg/cmd/exec/exec_test.go
@@ -1,0 +1,44 @@
+package exec
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/brevdev/brev-cli/pkg/entity"
+	"github.com/brevdev/brev-cli/pkg/terminal"
+)
+
+type noRetryExecStore struct {
+	ExecStore
+	lookupCalls int
+}
+
+func (s *noRetryExecStore) GetAuthTokens() (*entity.AuthTokens, error) {
+	return nil, nil
+}
+
+func (s *noRetryExecStore) GetCurrentUser() (*entity.User, error) {
+	s.lookupCalls++
+	return nil, errors.New("workspace lookup should not run for a remote command failure")
+}
+
+func TestRunExecCommandDoesNotRetryRemoteCommandFailure(t *testing.T) {
+	fakeBin := t.TempDir()
+	fakeSSH := filepath.Join(fakeBin, "ssh")
+	if err := os.WriteFile(fakeSSH, []byte("#!/bin/sh\nprintf '[]\\n'\nprintf 'Error: No such object: nosuchjob\\n' >&2\nexit 1\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", fakeBin+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("SSH_AUTH_SOCK", "test-agent")
+
+	store := &noRetryExecStore{}
+	err := runExecCommand(terminal.New(), store, "test-instance", false, "docker inspect nosuchjob")
+	if err == nil {
+		t.Fatal("expected the remote command failure to be returned")
+	}
+	if store.lookupCalls != 0 {
+		t.Fatalf("remote command failure entered the connection-recovery path %d time(s); want 0", store.lookupCalls)
+	}
+}


### PR DESCRIPTION
## Summary

- distinguish an ordinary remote command failure from SSH transport exit 255
- preserve the safe start-and-run behavior for a confirmed stopped instance
- never replay a command against an already-running instance after a connection failure, because it may already have executed
- add a regression test for the remote-failure recovery boundary

## NVBug

6669910.

## Validation

- baseline live reproducer on v0.6.334 emitted the Docker result twice from one invocation
- the same live reproducer with this change emitted the result once and retained exit status 1
- `go test ./pkg/cmd/exec -count=1`
- `go test -race ./pkg/cmd/exec -count=1`
- `go vet ./pkg/cmd/exec`
- `go test ./pkg/cmd/... -count=1`
