### PR TITLE
docs: quote the command argument in the exec usage string

### DIFF
--- a/pkg/cmd/exec/exec.go
+++ b/pkg/cmd/exec/exec.go
@@ -58,7 +58,7 @@ func NewCmdExec(t *terminal.Terminal, store ExecStore, noLoginStartStore ExecSto
 	var host bool
 	cmd := &cobra.Command{
 		Annotations:           map[string]string{"access": ""},
-		Use:                   "exec [instance...] <command>",
+		Use:                   `exec [instance...] "<command>"`,
 		DisableFlagsInUseLine: true,
 		Short:                 "Execute a command on instance(s)",
 		Long:                  execLong,

--- a/pkg/cmd/exec/exec.go
+++ b/pkg/cmd/exec/exec.go
@@ -34,6 +34,9 @@ var (
   brev exec my-instance @setup.sh
   brev exec my-instance @scripts/deploy.sh
 
+  # Run a background job
+  brev exec my-instance "nohup python train.py > /dev/null 2>&1 &"
+
   # Chain: create and run a command (reads instance names from stdin)
   brev create my-instance | brev exec "nvidia-smi"
 
@@ -57,8 +60,9 @@ type ExecStore interface {
 func NewCmdExec(t *terminal.Terminal, store ExecStore, noLoginStartStore ExecStore) *cobra.Command {
 	var host bool
 	cmd := &cobra.Command{
-		Annotations:           map[string]string{"access": ""},
-		Use:                   `exec [instance...] "<command>"`,
+		Annotations: map[string]string{"access": ""},
+		Use: `exec [instance...] "<command>"
+  brev exec [instance...] @<script-file-present-on-local>`,
 		DisableFlagsInUseLine: true,
 		Short:                 "Execute a command on instance(s)",
 		Long:                  execLong,


### PR DESCRIPTION
## Issue

The `brev exec` usage string showed: `exec [instance...] <command>`

However, `brev exec` treats only the final argument as the command; earlier arguments are treated as instance names. The usage string also didn't mention the `@<script-file>` form, which `brev exec` already supports.

## Fix

Updated the usage string to:

~~~

exec [instance...] "<command>"
brev exec [instance...] @<script-file-present-on-local>

~~~

- Also added a background job example to the help text.